### PR TITLE
Use `-t` instead of `-c` as shorthand for `--threshold`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ USAGE:
     docuum
 
 OPTIONS:
-    -c, --threshold <THRESHOLD>
-            Sets the maximum amount of space to be used for Docker images (default: 10 GB)
-
     -h, --help
             Prints help information
+
+    -t, --threshold <THRESHOLD>
+            Sets the maximum amount of space to be used for Docker images (default: 10 GB)
 
     -v, --version
             Prints version information

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn settings() -> io::Result<Settings> {
         .setting(AppSettings::UnifiedHelpMessage)
         .arg(
             Arg::with_name(THRESHOLD_ARG)
-                .short("c")
+                .short("t")
                 .long(THRESHOLD_ARG)
                 .value_name("THRESHOLD")
                 .help(&format!(


### PR DESCRIPTION
Use `-t` instead of `-c` as shorthand for `--threshold`.