### PR TITLE
Use HTTPS for the document type definition URL in the example property list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You probably want to run Docuum as a daemon, e.g., with [launchd](https://www.la
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
         <key>Label</key>


### PR DESCRIPTION
Use HTTPS for the document type definition URL in the example property list in the README.