### PR TITLE
Have Docuum wake up when an image is imported or loaded, not just when an image is built or pulled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2020-01-08
+
+### Fixed
+- Docuum now wakes up when an image is imported or loaded, not just when an image is built or pulled.
+
 ## [0.6.0] - 2020-01-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images"

--- a/src/run.rs
+++ b/src/run.rs
@@ -376,7 +376,9 @@ pub fn run(settings: &Settings, state: &mut State) -> io::Result<()> {
                 debug!("Invalid Docker event.");
                 continue;
             }
-        } else if event.r#type == "image" && event.action == "pull" {
+        } else if event.r#type == "image"
+            && (event.action == "import" || event.action == "load" || event.action == "pull")
+        {
             event.id
         } else {
             debug!("Skipping due to irrelevance.");


### PR DESCRIPTION
Have Docuum wake up when an image is imported or loaded, not just when an image is built or pulled.

**Status:** Ready

**Fixes:** N/A
