### PR TITLE
Publish Docuum as a Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,32 @@ OPTIONS:
 
 ## Installation
 
+### Running Docuum in a Docker container
+
+If you prefer not to install Docuum on your system, you can run it in a container. To run it in the foreground:
+
+```sh
+docker run \
+  --init \
+  --rm \
+  --tty \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume docuum:/root \
+  stephanmisc/docuum
+```
+
+To run it in the background:
+
+```sh
+docker run \
+  --detach \
+  --init \
+  --rm \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume docuum:/root \
+  stephanmisc/docuum
+```
+
 ### Easy installation
 
 If you are running macOS or a GNU-based Linux on an x86-64 CPU, you can install Docuum with this command:

--- a/release.sh
+++ b/release.sh
@@ -7,10 +7,15 @@ set -euo pipefail
 
 # The release process involves three pull requests:
 # 1. Bump the version in `Cargo.toml`, run `cargo build` to update `Cargo.lock`, and update
-#    `CHANGELOG.md` with information about the new version. Once this PR is merged, run
-#    `cargo publish`.
-# 2. Run this script and upload the files in the `release` directory to GitHub as release artifacts.
-# 3. Update the version in `install.sh` to point to the new release.
+#    `CHANGELOG.md` with information about the new version. Ship those changes as a pull request.
+# 2. Run `cargo publish`.
+# 3. Run this script and upload the files in the `release` directory to GitHub as release artifacts.
+# 4. Build and upload the Docker image:
+#      cd release
+#      docker build --tag stephanmisc/docuum:0.8.0 .
+#      docker push stephanmisc/docuum:0.8.0
+# 5. Update the version in `install.sh` to point to the new release. Ship that change as another
+#    pull request.
 
 # We wrap everything in parentheses to ensure that any working directory changes with `cd` are local
 # to this script and don't affect the calling user's shell.

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,0 +1,34 @@
+# A base image with glibc
+FROM debian:buster-slim
+
+# Install the Docker CLI.
+RUN \
+  apt-get update && \
+  apt-get install --yes \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
+  add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/debian buster stable" && \
+  apt-get update && \
+  apt-get install --yes docker-ce-cli && \
+  apt-get remove --yes \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    software-properties-common \
+    && \
+  apt-get autoremove --yes && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install Docuum.
+COPY docuum-x86_64-unknown-linux-gnu /usr/local/bin/docuum
+
+# Set the entrypoint to Docuum. Note that Docuum is not intended to be run as
+# an init process, so we run it indirectly via `sh`.
+ENTRYPOINT ["/usr/local/bin/docuum"]


### PR DESCRIPTION
Publish Docuum as a Docker image (for people who prefer not to actually install it).

**Status:** Ready

**Fixes:** N/A
