### PR TITLE
Consider unrecognized images to be brand new, rather than as old as the UNIX epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2020-01-17
+
+### Fixed
+- Unrecognized images are considered to be brand new, rather than as old as the UNIX epoch.
+
 ## [0.8.0] - 2020-01-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images"


### PR DESCRIPTION
Consider unrecognized images to be brand new, rather than as old as the UNIX epoch. This addresses a potential race involving the following sequence of events:

1. Docuum wakes up (doesn't matter why)
2. An image is created after Docuum has already started vacuuming
3. Docuum does not recognize the image and marks it as old (fixed by this PR)
4. Docuum deletes the newly created image

**Status:** Ready

**Fixes:** N/A
