### PR TITLE
Fix a bug in which Docuum could enter a crash loop by repeatedly trying to query the ID of an image that no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2020-02-01
+
+### Fixed
+- Fixed a bug in which Docuum could enter a crash loop by repeatedly trying to query the ID of an image that no longer exists. This would happen when there is a container that points to such an image.
+
 ## [0.9.1] - 2020-01-29
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images"


### PR DESCRIPTION
Fix a bug in which Docuum could enter a crash loop by repeatedly trying to query the ID of an image that no longer exists. This would happen when there is a container that points to such an image.

**Status:** Ready

**Fixes:** N/A
