### PR TITLE
Add a `--name` option to the example `docker run` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ docker run \
   --init \
   --rm \
   --tty \
+  --name docuum \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume docuum:/root \
   stephanmisc/docuum --threshold '15 GB'
@@ -101,6 +102,7 @@ docker run \
   --detach \
   --init \
   --rm \
+  --name docuum \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume docuum:/root \
   stephanmisc/docuum --threshold '15 GB'


### PR DESCRIPTION
Add a `--name` option to the example `docker run` commands. That way, Docker will complain if you accidentally run two instances of it (which would generally be a mistake).

**Status:** Ready

**Fixes:** N/A
