### PR TITLE
Consider all known image events to be "uses" of the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2020-02-12
+
+### Fixed
+- Fixed a bug in which Docuum would not consider certain image events as "uses" of the image.
+
 ## [0.9.2] - 2020-02-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images"

--- a/src/run.rs
+++ b/src/run.rs
@@ -395,7 +395,14 @@ pub fn run(settings: &Settings, state: &mut State) -> io::Result<()> {
                     continue;
                 }
             } else if event.r#type == "image"
-                && (event.action == "import" || event.action == "load" || event.action == "pull")
+                && (event.action == "delete"
+                    || event.action == "import"
+                    || event.action == "load"
+                    || event.action == "pull"
+                    || event.action == "push"
+                    || event.action == "save"
+                    || event.action == "tag"
+                    || event.action == "untag")
             {
                 event.id
             } else {


### PR DESCRIPTION
Consider all known image events to be "uses" of the image. The list of image events comes from [here](https://docs.docker.com/engine/reference/commandline/events/).

To test this, I did a quick sanity check by trying out some of these events and watching the Docker event stream:

```
docker events --format '{{json .}}'
{"status":"tag","id":"sha256:549b9b86cb8d75a2b668c21c50ee092716d070f129fd1493f95ab7e43767eab8","Type":"image","Action":"tag","Actor":{"ID":"sha256:549b9b86cb8d75a2b668c21c50ee092716d070f129fd1493f95ab7e43767eab8","Attributes":{"name":"foo:latest"}},"scope":"local","time":1581547942,"timeNano":1581547942279415100}
{"status":"untag","id":"sha256:549b9b86cb8d75a2b668c21c50ee092716d070f129fd1493f95ab7e43767eab8","Type":"image","Action":"untag","Actor":{"ID":"sha256:549b9b86cb8d75a2b668c21c50ee092716d070f129fd1493f95ab7e43767eab8","Attributes":{"name":"sha256:549b9b86cb8d75a2b668c21c50ee092716d070f129fd1493f95ab7e43767eab8"}},"scope":"local","time":1581547993,"timeNano":1581547993016642300}
{"status":"tag","id":"sha256:549b9b86cb8d75a2b668c21c50ee092716d070f129fd1493f95ab7e43767eab8","Type":"image","Action":"tag","Actor":{"ID":"sha256:549b9b86cb8d75a2b668c21c50ee092716d070f129fd1493f95ab7e43767eab8","Attributes":{"name":"stephanmisc/foo:foo"}},"scope":"local","time":1581548007,"timeNano":1581548007267375700}
{"status":"push","id":"stephanmisc/foo:foo","Type":"image","Action":"push","Actor":{"ID":"stephanmisc/foo:foo","Attributes":{"name":"stephanmisc/foo"}},"scope":"local","time":1581548020,"timeNano":1581548020987693900}
...
```

I also had Docuum running and observed that Docuum responded to these.

**Status:** Ready

**Fixes:** N/A
