### PR TITLE
Don't consider `delete` or `untag` image events as "uses" of the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2020-02-12
+
+### Changed
+- Docuum no longer considers the `delete` or `untag` image events to be "uses" of the image.
+
 ## [0.9.3] - 2020-02-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images"

--- a/src/run.rs
+++ b/src/run.rs
@@ -395,14 +395,12 @@ pub fn run(settings: &Settings, state: &mut State) -> io::Result<()> {
                     continue;
                 }
             } else if event.r#type == "image"
-                && (event.action == "delete"
-                    || event.action == "import"
+                && (event.action == "import"
                     || event.action == "load"
                     || event.action == "pull"
                     || event.action == "push"
                     || event.action == "save"
-                    || event.action == "tag"
-                    || event.action == "untag")
+                    || event.action == "tag")
             {
                 event.id
             } else {


### PR DESCRIPTION
Don't consider `delete` or `untag` image events as "uses" of the image. This change was suggested by @vhain.

**Status:** Ready

**Fixes:** N/A
