### PR TITLE
Use underscores rather than hyphens to separate words in tags

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -331,7 +331,7 @@ fn vacuum(state: &mut State, threshold: &Byte) -> io::Result<()> {
         );
     }
 
-    // Persist the state [tag:vacuum-persists-state].
+    // Persist the state [tag:vacuum_persists_state].
     state::save(&state)?;
 
     // Inform the user that we're done for now.
@@ -412,7 +412,7 @@ pub fn run(settings: &Settings, state: &mut State) -> io::Result<()> {
         // Update the timestamp for this image.
         update_timestamp(state, &image_id, true)?;
 
-        // Run the main vacuum logic. This will also persist the state [ref:vacuum-persists-state].
+        // Run the main vacuum logic. This will also persist the state [ref:vacuum_persists_state].
         vacuum(state, &settings.threshold)?;
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,7 +18,7 @@ pub struct State {
 
 // Where the program state is persisted on disk
 fn path() -> Option<PathBuf> {
-    // [tag:state-path-has-parent]
+    // [tag:state_path_has_parent]
     dirs::data_local_dir().map(|path| path.join("docuum/state.yml"))
 }
 
@@ -63,7 +63,7 @@ pub fn save(state: &State) -> io::Result<()> {
             path.to_string_lossy().code_str(),
         );
 
-        // The `unwrap` is safe due to [ref:state-path-has-parent].
+        // The `unwrap` is safe due to [ref:state_path_has_parent].
         let parent = path.parent().unwrap().to_owned();
 
         // The `unwrap` is safe because serialization should never fail.


### PR DESCRIPTION
Use underscores rather than hyphens to separate words in tags.

**Status:** Ready

**Fixes:** N/A
