### PR TITLE
Re-enable the `use_self` lint check now that it has been fixed upstream

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -9,9 +9,6 @@ pub trait CodeStr {
 }
 
 impl CodeStr for str {
-    // This particular lint check is buggy and reports a nonsensical error in this function, so we
-    // disable it here.
-    #![allow(clippy::use_self)]
     fn code_str(&self) -> ColoredString {
         // If colored output is enabled, format the text in magenta. Otherwise, surround it in
         // backticks.


### PR DESCRIPTION
Re-enable the `use_self` lint check now that it has been fixed upstream.

**Status:** Ready

**Fixes:** N/A
