### PR TITLE
Set initial timestamp to the time the image was created

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -8,8 +8,7 @@ use chrono::DateTime;
 use scopeguard::guard;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     io::{self, BufRead, BufReader},
     process::{Command, Stdio},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -108,13 +107,10 @@ pub fn image_ids() -> io::Result<HashMap<String, Duration>> {
                     continue;
                 }
                 let tab_index = line.find('\t').ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::Other, "Failed to split image ID and date")
+                    io::Error::new(io::ErrorKind::Other, "Failed to split image ID and date.")
                 })?;
                 let (image_id, date_str) = line.split_at(tab_index);
-                match parse_docker_date(&date_str) {
-                    Ok(duration) => images.insert(image_id.trim().to_owned(), duration),
-                    Err(e) => return Err(e),
-                };
+                images.insert(image_id.trim().to_owned(), parse_docker_date(&date_str)?);
             }
             Ok(images)
         })
@@ -126,7 +122,7 @@ fn parse_docker_date(date_str: &str) -> io::Result<Duration> {
     // Chrono can't read the "EST", so remove it before parsing
     let clean_date_str =
         date_str.trim().rsplitn(2, ' ').last().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "Failed to remove timezone string")
+            io::Error::new(io::ErrorKind::Other, "Failed to remove timezone string.")
         })?;
     // Parse the date and convert into a time::Duration since the epoch
     let old_duration = match DateTime::parse_from_str(&clean_date_str, "%Y-%m-%d %H:%M:%S %z") {

--- a/toast.yml
+++ b/toast.yml
@@ -94,7 +94,7 @@ tasks:
       . $HOME/.cargo/env
       cargo clippy --all-targets --all-features -- \
         --deny warnings --deny clippy::all --deny clippy::pedantic
-      cargo fmt --all -- --check || echo "ERROR: Please correct the formatting errors above"
+      cargo fmt --all -- --check || echo 'ERROR: Please correct the formatting errors above.' 1>&2
       tagref
       shellcheck install.sh
       shellcheck release.sh

--- a/toast.yml
+++ b/toast.yml
@@ -94,7 +94,7 @@ tasks:
       . $HOME/.cargo/env
       cargo clippy --all-targets --all-features -- \
         --deny warnings --deny clippy::all --deny clippy::pedantic
-      cargo fmt --all -- --check
+      cargo fmt --all -- --check || echo "ERROR: Please correct the formatting errors above"
       tagref
       shellcheck install.sh
       shellcheck release.sh


### PR DESCRIPTION
Previously, when docuum first starts, it would set the timestamp of every image to the time docuum started, meaning old images would be removed at random. Now, we use the time the image was created as the initial timestamp (which is of course updated when that image is used like normal).

Example running locally (with comments added to show the original CreatedAt dates):
```
$ cargo run -- --threshold '50 GB'
   Compiling docuum v0.9.5 (/Users/machaffe/personal/docuum)
    Finished dev [unoptimized + debuginfo] target(s) in 3.81s
     Running `target/debug/docuum --threshold '50 GB'`
[2020-07-17 18:20:11 -04:00 INFO] Waking up…
[2020-07-17 18:20:11 -04:00 INFO] Docker images are currently using 75.27 GB but the limit is 50.00 GB. Some images will be deleted.
[2020-07-17 18:20:12 -04:00 INFO] Deleting image sha256:3129a2ca29d75226dc5657a4629cdd5f38accda7f5b75bc5d5a76f5b4e0e5870…
Untagged: quay.io/coreos/configmap-reload:v0.0.1            <--- CreatedAt Feb 2017
Untagged: quay.io/coreos/configmap-reload@sha256:e2fd60ff0ae4500a75b80ebaa30e0e7deba9ad107833e8ca53f0047c42c5a057
Deleted: sha256:3129a2ca29d75226dc5657a4629cdd5f38accda7f5b75bc5d5a76f5b4e0e5870
Deleted: sha256:0065890d4ef6d9e21ba99dea6a990abe8b53db0b82562fe68dd3f37ef529b156
Deleted: sha256:91bd48b9e0b007ce035cccf10d1dc7e482695cf492c94808875fa84e71a85482
[2020-07-17 18:20:12 -04:00 INFO] Deleting image sha256:2faf6f7a322f5f8d565e05675d5ab6f4d1b4a4f65f88cb14df15e76b902b0536…
Untagged: quay.io/coreos/hyperkube:v1.7.6_coreos.0           <--- CreatedAt Sep 2017
Untagged: quay.io/coreos/hyperkube@sha256:699fc03fccb1c4662fee9d996cf30106aea55a6f594d16c1504cc7334dadcee4
Deleted: sha256:2faf6f7a322f5f8d565e05675d5ab6f4d1b4a4f65f88cb14df15e76b902b0536
Deleted: sha256:e5f68041508088cc8a24342143cb911297b424db7cfd8c2f4362124382a9eaf3
Deleted: sha256:3b91c2286ccf87e35ab72d4fbcc66f7b0d6834408c69726d250d778759c75359
Deleted: sha256:713bebfb34f9e43249fd9c44b3c935a0fcdc8575a02822f4fbfc65f6fd6a89d4
Deleted: sha256:c18c4811ea9f56e6561adc47460f2a42937e33b3e6782911ea4a3f36f01438c1
Deleted: sha256:fed386583ce4ea496bad7914fc503d437f8ba8d3590fb7c69ed8c526f879d6c0
Deleted: sha256:18f9b4e2e1bcd5abe381a557c44cba379884c88f6049564f58fd8c10ab5733df
[2020-07-17 18:20:14 -04:00 INFO] Deleting image sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e…
Error response from daemon: conflict: unable to delete da86e6ba6ca1 (cannot be forced) - image is being used by running container ac477f13429f
[2020-07-17 18:20:14 -04:00 ERROR] Unable to delete image sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e.
[2020-07-17 18:20:14 -04:00 INFO] Deleting image sha256:c81481184b1b001f225769d1482b360b4be18fe7dd53fa93cdbd45d568e905a7…
Untagged: justincormack/nsenter1:latest                      <--- CreatedAt Jan 2018
Untagged: justincormack/nsenter1@sha256:5af0be5e42ebd55eea2c593e4622f810065c3f45bb805eaacf43f08f3d06ffd8
Deleted: sha256:c81481184b1b001f225769d1482b360b4be18fe7dd53fa93cdbd45d568e905a7
Deleted: sha256:c43e635df3c82c2f4ce61495e8440e23ed6001c7c26c8353e6b743459a97d60e
<truncated>
```

Also this is my first foray into Rust, so please let me know if there are any best-practices I should be following, particularly around error handling 👍 

**Status:** Ready

**Fixes:** #71 
