### PR TITLE
Upgrade Rust to v1.46.0

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -27,7 +27,7 @@ tasks:
     command: |
       set -euo pipefail
       curl https://sh.rustup.rs -sSf |
-        sh -s -- -y --default-toolchain 1.41.0
+        sh -s -- -y --default-toolchain 1.46.0
       . $HOME/.cargo/env
       rustup component add clippy
       rustup component add rustfmt


### PR DESCRIPTION
Upgrade Rust to v1.46.0.

**Status:** Ready

**Fixes:** N/A
