### PR TITLE
Install v0.13.1 by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/docuum"
 
   # Which version to download
-  RELEASE="v${VERSION:-0.13.0}"
+  RELEASE="v${VERSION:-0.13.1}"
 
   # Determine which binary to download.
   FILENAME=''

--- a/release.sh
+++ b/release.sh
@@ -18,13 +18,13 @@ set -euo pipefail
 # We wrap everything in parentheses to ensure that any working directory changes with `cd` are local
 # to this script and don't affect the calling user's shell.
 (
-  # x86-64 GNU/Linux build
-  rm -rf artifacts
-  toast release
-
   # x86-64 macOS build
   rm -rf target/release
   cargo build --release
+
+  # x86-64 GNU/Linux build
+  rm -rf artifacts
+  toast release
 
   # Prepare the `release` directory.
   rm -rf release

--- a/toast.yml
+++ b/toast.yml
@@ -134,8 +134,7 @@ tasks:
 
   release:
     dependencies:
-      - test
-      - lint
+      - fetch_crates
     input_paths:
       - src
     output_paths:


### PR DESCRIPTION
Install v0.13.1 by default.

I also reverted some of the release automation to how it was a few commits back, because a recent change made it take way too long. I didn't measure it, but it felt like about 2 hours on my little MacBook Air. We don't need to re-run the tests/linters/etc when doing a release, because we only release commits on master that have already passed those checks.

**Status:** Ready

**Fixes:** N/A
