### PR TITLE
Create temp state.yml in the same folder (to prevent os error 18)

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -83,10 +83,10 @@ pub fn save(state: &State) -> io::Result<()> {
         let payload = serde_yaml::to_string(state).unwrap();
 
         // Create the ancestor directories, if needed.
-        create_dir_all(parent)?;
+        create_dir_all(parent.clone())?;
 
         // Persist the state to disk.
-        let mut temp_file = NamedTempFile::new()?;
+        let mut temp_file = NamedTempFile::new_in(parent)?;
         temp_file.write_all(payload.as_bytes())?;
         temp_file.flush()?;
         temp_file.persist(path)?;


### PR DESCRIPTION
Now the temporary copy of state.yml (that is created for atomic writes) will be created in the same directory as the original state.yml.

This is needed since the default location of NamedTempFile is usually somewhere like `/tmp`, which may be a different filesystem if the `/root` directory is a mouted docker volume.  And renaming files atomically does not work across file systems: https://man7.org/linux/man-pages/man2/rename.2.html#:~:text=EXDEV

Tested locally:

```
$ docker run   --init   --rm   --name docuum   --volume /var/run/docker.sock:/var/run/docker.sock   --volume docuum:/root   sha256:851a73e269f2302a56cb725de98d966f2e894b1ca099dae2394d129a5f23358e --threshold '19 GB'
[2020-10-10 20:59:48 +00:00 INFO] Performing an initial vacuum on startup…
[2020-10-10 20:59:49 +00:00 INFO] Docker images are using `18.97 GB`, which is within the limit of `19.00 GB`.
[2020-10-10 20:59:49 +00:00 INFO] Listening for Docker events…
[2020-10-10 21:02:35 +00:00 INFO] Waking up…
[2020-10-10 21:02:35 +00:00 INFO] Updating last-used timestamp for image `sha256:a24bb4013296f61e89ba57005a7b3e52274d8edd3ae2077d04395f806b63d83e`…
[2020-10-10 21:02:36 +00:00 INFO] Docker images are using `18.97 GB`, which is within the limit of `19.00 GB`.
[2020-10-10 21:02:36 +00:00 INFO] Going back to sleep…
```

Also ran inotifywait at the same time to show the new sequence of file operations in` /root/.local/share/docuum/`:
```
root@167d9136e1ec:~/.local/share/docuum# inotifywait -m .
Setting up watches.
Watches established.
./ OPEN,ISDIR
./ ACCESS,ISDIR
./ CLOSE_NOWRITE,CLOSE,ISDIR
./ CREATE .tmpwCgT2d
./ OPEN .tmpwCgT2d
./ MODIFY .tmpwCgT2d
./ MOVED_FROM .tmpwCgT2d
./ MOVED_TO state.yml
./ CLOSE_WRITE,CLOSE state.yml
```

**Status:** Ready

**Fixes:** #109 
