### PR TITLE
Install v0.15.1 by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
   DESTINATION="${PREFIX:-/usr/local/bin}/docuum"
 
   # Which version to download
-  RELEASE="v${VERSION:-0.15.0}"
+  RELEASE="v${VERSION:-0.15.1}"
 
   # Determine which binary to download.
   FILENAME=''


### PR DESCRIPTION
Install v0.15.1 by default now that it is released.

cc @mac-chaffee

**Status:** Ready

**Fixes:** N/A
