### PR TITLE
Make the instructions for pushing Docker image releases safer

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,8 +11,9 @@ set -euo pipefail
 #    request.
 # 2. Run this script and upload the files in the `release` directory to GitHub as release artifacts.
 # 3. Build and upload the Docker image:
-#      docker build --tag stephanmisc/docuum --tag stephanmisc/docuum:X.Y.Z .
-#      docker push stephanmisc/docuum
+#      docker build --tag stephanmisc/docuum:latest --tag stephanmisc/docuum:X.Y.Z .
+#      docker push stephanmisc/docuum:latest
+#      docker push stephanmisc/docuum:X.Y.Z
 # 4. Update the version in `install.sh` to point to the new release.
 
 # We wrap everything in parentheses to ensure that any working directory changes with `cd` are local


### PR DESCRIPTION
Make the instructions for pushing Docker image releases safer. The current push command (`docker push stephanmisc/docuum`) pushes _all_ tags, which is not the desired behavior when releasing a single version. After this change, the commands will refer to specific tags explicitly to avoid accidentally pushing more tags than intended.

**Status:** Ready

**Fixes:** N/A
