### PR TITLE
Add integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,14 @@ jobs:
       if: github.event_name == 'push'
     - uses: stepchowfun/toast/.github/actions/toast@master
       with:
-        tasks: build test lint run
+        tasks: build test lint run release-musl
         repo: stephanmisc/toast
         write_remote_cache: ${{ github.event_name == 'push' }}
+    - name: Integration Test
+      run: |
+        docker run --privileged --name dind -d \
+          -v $PWD/artifacts:/artifacts docker:dind
+        docker exec dind apk add bash
+        docker cp integration_test.sh dind:/
+        docker exec -i dind ./integration_test.sh
+        docker rm -f dind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,11 @@ jobs:
         tasks: build check test lint run release-musl
         repo: stephanmisc/toast
         write_remote_cache: ${{ github.event_name == 'push' }}
+    # [tag:integration_test_step]
     - name: Integration Test
       run: |
         docker run --privileged --name dind -d \
-          -v $PWD/artifacts:/artifacts docker:dind
+          -v "$PWD/artifacts:/artifacts" docker:dind
         docker exec dind apk add bash
         docker cp integration_test.sh dind:/
         docker exec -i dind ./integration_test.sh

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -3,6 +3,19 @@ set -Eemo pipefail
 # This script is meant to be run inside https://hub.docker.com/_/docker
 # See .github/workflows/ci.yml:18 for how to run this yourself
 
+# Wait for the docker daemon to start up
+for i in {1..30}; do
+    if docker ps; then
+        break
+    else
+        sleep 1
+    fi
+done
+if [ "$i" = '30' ]; then
+    echo "Docker did not start within 30 seconds, aborting"
+    exit 1
+fi
+
 # Start docuum in the background
 /artifacts/docuum-x86_64-unknown-linux-musl --threshold=13MB &
 sleep 1
@@ -15,10 +28,10 @@ function wait {
             break
         fi
         echo "Waiting for docuum to finish one loop..."
-        sleep 2
+        sleep 1
     done
     if [ "$i" = '60' ]; then
-        echo "Docuum did not finish a loop within 2 minutes, aborting"
+        echo "Docuum did not finish a loop within 1 minute, aborting"
         exit 1
     fi
 }

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -Eemo pipefail
+set -Eemuo pipefail
 # This script is meant to be run inside https://hub.docker.com/_/docker
-# See .github/workflows/ci.yml:18 for how to run this yourself
+# See [ref:integration_test_step] for how to run this yourself.
 
 # Wait for the docker daemon to start up
 for i in {1..30}; do
@@ -12,47 +12,47 @@ for i in {1..30}; do
     fi
 done
 if [ "$i" = '30' ]; then
-    echo "Docker did not start within 30 seconds, aborting"
+    echo "Docker did not start within 30 seconds. Aborting…"
     exit 1
 fi
 
-# Start docuum in the background
+# Start Docuum in the background.
 /artifacts/docuum-x86_64-unknown-linux-musl --threshold=13MB &
-sleep 1
+
 # Wait for docuum to start sleeping by checking the process state
-function wait {
+function wait_for_docuum {
+    # Explicitly sleep to prevent `docker exec` crashing while reading /proc
+    # sleep 1
     # http://man7.org/linux/man-pages/man5/proc.5.html
-    DOCUUM_PID=$(pgrep docuum-x86_64-unknown-linux-musl)
     for i in {1..60}; do
-        if [ "$(awk '{ print $3 }' /proc/${DOCUUM_PID}/stat)" = 'S' ]; then
+        if [[ "$(awk '{ print $3 }' /proc/$!/stat)" = 'S' ]]; then
             break
         fi
-        echo "Waiting for docuum to finish one loop..."
+        echo "Waiting for Docuum to finish one loop…"
         sleep 1
     done
-    if [ "$i" = '60' ]; then
-        echo "Docuum did not finish a loop within 1 minute, aborting"
+    if [[ "$i" = '60' ]]; then
+        echo 'Docuum did not finish a loop within 60 seconds. Aborting…' >&2
         exit 1
     fi
 }
 
-wait
+wait_for_docuum
 
-# ~5.5MB
+# ~5.5 MB
 docker run alpine@sha256:4716d67546215299bf023fd80cc9d7e67f4bdc006a360727fd0b0b44512c45db true
-# ~5.5MB
+# ~5.5 MB
 docker run alpine@sha256:fef20cf0221c5c0eaae2d8f59081b07cd351a94ac83cdc74109b17ec90ce0a82 true
-# ~5.5MB (now more than the 13MB threshold)
+# ~5.5 MB (now more than the 13 MB threshold)
 docker run alpine@sha256:6b987122c635cd4bf46e52d85bca765732c7a224866501742c549ccc852f8c53 true
 
-wait
+wait_for_docuum
 
 # Assert the two most-recently-used alpine images are still present
 docker inspect alpine@sha256:6b987122c635cd4bf46e52d85bca765732c7a224866501742c549ccc852f8c53 > /dev/null
 docker inspect alpine@sha256:fef20cf0221c5c0eaae2d8f59081b07cd351a94ac83cdc74109b17ec90ce0a82 > /dev/null
 # Assert the first alpine image was removed
-! docker inspect alpine@sha256:4716d67546215299bf023fd80cc9d7e67f4bdc006a360727fd0b0b44512c45db > /dev/null 2>&1 || { echo "The first alpine image should have been deleted."; false; }
-
+! docker inspect alpine@sha256:4716d67546215299bf023fd80cc9d7e67f4bdc006a360727fd0b0b44512c45db > /dev/null 2>&1 || { echo "The first alpine image should have been deleted." >&2; false; }
 kill $!
 
 echo "Integration test passed!"

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -3,7 +3,7 @@ set -Eemuo pipefail
 # This script is meant to be run inside https://hub.docker.com/_/docker
 # See [ref:integration_test_step] for how to run this yourself.
 
-# Wait for the docker daemon to start up
+# Wait for the Docker daemon to start up.
 for i in {1..30}; do
     if docker ps; then
         break

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -Eemo pipefail
+# This script is meant to be run inside https://hub.docker.com/_/docker
+# See .github/workflows/ci.yml:18 for how to run this yourself
+
+# Start docuum in the background
+/artifacts/docuum-x86_64-unknown-linux-musl --threshold=13MB &
+sleep 1
+# Wait for docuum to start sleeping by checking the process state
+function wait {
+    # http://man7.org/linux/man-pages/man5/proc.5.html
+    DOCUUM_PID=$(pgrep docuum-x86_64-unknown-linux-musl)
+    for i in {1..60}; do
+        if [ "$(awk '{ print $3 }' /proc/${DOCUUM_PID}/stat)" = 'S' ]; then
+            break
+        fi
+        echo "Waiting for docuum to finish one loop..."
+        sleep 2
+    done
+    if [ "$i" = '60' ]; then
+        echo "Docuum did not finish a loop within 2 minutes, aborting"
+        exit 1
+    fi
+}
+
+wait
+
+# ~5.5MB
+docker run alpine@sha256:4716d67546215299bf023fd80cc9d7e67f4bdc006a360727fd0b0b44512c45db true
+# ~5.5MB
+docker run alpine@sha256:fef20cf0221c5c0eaae2d8f59081b07cd351a94ac83cdc74109b17ec90ce0a82 true
+# ~5.5MB (now more than the 13MB threshold)
+docker run alpine@sha256:6b987122c635cd4bf46e52d85bca765732c7a224866501742c549ccc852f8c53 true
+
+wait
+
+# Assert the two most-recently-used alpine images are still present
+docker inspect alpine@sha256:6b987122c635cd4bf46e52d85bca765732c7a224866501742c549ccc852f8c53 > /dev/null
+docker inspect alpine@sha256:fef20cf0221c5c0eaae2d8f59081b07cd351a94ac83cdc74109b17ec90ce0a82 > /dev/null
+# Assert the first alpine image was removed
+! docker inspect alpine@sha256:4716d67546215299bf023fd80cc9d7e67f4bdc006a360727fd0b0b44512c45db > /dev/null 2>&1 || { echo "The first alpine image should have been deleted."; false; }
+
+kill $!
+
+echo "Integration test passed!"

--- a/toast.yml
+++ b/toast.yml
@@ -147,3 +147,19 @@ tasks:
       mkdir artifacts
       sha256sum --binary target/release/docuum
       cp target/release/docuum artifacts/docuum-x86_64-unknown-linux-gnu
+
+  release-musl:
+    dependencies:
+      - fetch_crates
+    input_paths:
+      - src
+    output_paths:
+      - artifacts
+    user: user
+    command: |
+      set -euo pipefail
+      . $HOME/.cargo/env
+      rustup target add x86_64-unknown-linux-musl
+      cargo build --release --target x86_64-unknown-linux-musl
+      mkdir artifacts
+      cp target/x86_64-unknown-linux-musl/release/docuum artifacts/docuum-x86_64-unknown-linux-musl


### PR DESCRIPTION
Added an integration test which works as follows:

1. Toast compiles Docuum to run inside Alpine Linux
2. The Github Action starts a docker container which itself contains a docker daemon (the docker-in-docker image is based on alpine https://hub.docker.com/_/docker/). And the musl docuum binary is volume-mounted in.
3. `integration_test.sh` is copied into the container
4. `integration_test.sh`:
    - starts docuum
    - runs 3 docker containers (the last container causes disk space usage to surpass the threshold given to docuum)
    - waits for docuum to finish working (by checking `/proc` to see if the process is sleeping)
    - then asserts that only the Least Recently Used container was removed

**Tested**
https://github.com/mac-chaffee/docuum/runs/1237194204?check_suite_focus=true

**Tradeoffs**

* I couldn't just run docuum on the Github Actions VM directly since there are always images already on the VM (usually from Toast). So it's hard to make assertions about docuum's behavior when you can't start with a pristine docker daemon.
* I couldn't get this to work inside Toast since I didn't see a way to run the `docker:dind` image for a specific task. If there's a way to choose a different image for only one task, I could re-work this to be a toast task.
* There's a lot of bash here. I guess in theory you could write a test in Rust, but you'd need to cross-compile it to a binary you can run in `docker:dind`, or install a rust compiler in there
* This test is kinda limited. None of the [6 bugs reported so far](https://github.com/stepchowfun/docuum/issues?q=label%3Abug) would have been caught by this test. Would need to expand it to test Buildkit, long-running behaviors, deletion order of specific layers, volume mounting, etc. if we want to catch those bugs specifically.


So lots of tradeoffs, but at least the work to get docuum running inside `docker:dind` and talking to a pristine docker daemon might be a good starting point for future integration testing. 


**Status:** Ready

**Fixes:** #84
