### PR TITLE
Bump the version to v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "atty",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images"


### PR DESCRIPTION
Bump the version to v0.16.0. (The CHANGELOG was already updated in https://github.com/stepchowfun/docuum/pull/116.)

**Status:** Ready

**Fixes:** N/A
