### PR TITLE
Clarify a comment in the Dockerfile about not running Docuum as an init process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ RUN \
 COPY release/docuum-x86_64-unknown-linux-gnu /usr/local/bin/docuum
 
 # Set the entrypoint to Docuum. Note that Docuum is not intended to be run as
-# an init process, so we run it indirectly via `sh`.
+# an init process, so be sure to pass `--init` to `docker run`.
 ENTRYPOINT ["/usr/local/bin/docuum"]


### PR DESCRIPTION
Clarify a comment in the Dockerfile about not running Docuum as an init process.

**Status:** Ready

**Fixes:** N/A
