### PR TITLE
feat: build static msvc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,10 @@ jobs:
         rustup default 1.53.0 # [ref:rust_1_53_0]
 
         # Build and test.
-        RUSTFLAGS='-C target-feature=+crt-static' cargo build --locked --release --target x86_64-pc-windows-msvc
+        RUSTFLAGS='--codegen target-feature=+crt-static' cargo build \
+          --locked \
+          --release \
+          --target x86_64-pc-windows-msvc
         NO_COLOR=true cargo test --locked # [ref:colorless_tests]
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         rustup default 1.53.0 # [ref:rust_1_53_0]
 
         # Build and test.
-        cargo build --locked --release --target x86_64-pc-windows-msvc
+        RUSTFLAGS='-C target-feature=+crt-static' cargo build --locked --release --target x86_64-pc-windows-msvc
         NO_COLOR=true cargo test --locked # [ref:colorless_tests]
     - uses: actions/upload-artifact@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2021-07-13
+
+### Changed
+- Windows binary is now static linked, so no msvc libaries are required.
+
 ## [0.18.1] - 2021-07-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "atty",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images."


### PR DESCRIPTION
Compile windows binaries with static crt, so no runtime libs are required. see #83 

**Status:** Ready 


