### PR TITLE
fix: use `LOCALAPPDATA` env on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.19.1] - 2021-07-13
 
 ### Fixed
-- Use `LOCALAPPDATA` on windows because `dirs::data_local_dir()` is empty on windows nano server
+- Use `LOCALAPPDATA` on windows when `dirs::data_local_dir()` is `None` which happens on `mcr.microsoft.com/windows/nanoserver` Docker image.
 
 ## [0.19.0] - 2021-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2021-07-13
+
+### Fixed
+- Use `LOCALAPPDATA` on windows because `dirs::data_local_dir()` is empty on windows nano server
+
 ## [0.19.0] - 2021-07-13
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "atty",
  "byte-unit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "atty",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images."

--- a/src/state.rs
+++ b/src/state.rs
@@ -34,7 +34,7 @@ pub struct State {
 fn path() -> Option<PathBuf> {
     let mut base_path = dirs::data_local_dir();
 
-    // Overwrite the directory on Windows because it's empty in nanoserver
+    // Overwrite the directory on Windows because it's empty in nanoserver.
     if cfg!(windows) {
         if let Ok(local_dir) = env::var("LOCALAPPDATA") {
             base_path = Option::Some(Path::new(&local_dir).to_path_buf())

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,9 +2,10 @@ use crate::format::CodeStr;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
+    env,
     fs::{create_dir_all, read_to_string},
     io::{self, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::Duration,
 };
 use tempfile::NamedTempFile;
@@ -31,8 +32,17 @@ pub struct State {
 
 // Where the program state is persisted on disk
 fn path() -> Option<PathBuf> {
+    let mut base_path = dirs::data_local_dir();
+
+    // Overwrite the directory on Windows because it's empty in nanoserver
+    if cfg!(windows) {
+        if let Ok(local_dir) = env::var("LOCALAPPDATA") {
+            base_path = Option::Some(Path::new(&local_dir).to_path_buf())
+        }
+    }
+
     // [tag:state_path_has_parent]
-    dirs::data_local_dir().map(|path| path.join("docuum/state.yml"))
+    base_path.map(|path| path.join("docuum/state.yml"))
 }
 
 // Return the state in which the program starts, if no state was loaded from disk.

--- a/src/state.rs
+++ b/src/state.rs
@@ -35,7 +35,7 @@ fn path() -> Option<PathBuf> {
     let mut base_path = dirs::data_local_dir();
 
     // Overwrite the directory on Windows because it's empty in nanoserver.
-    if cfg!(windows) {
+    if base_path.is_none() && cfg!(windows) {
         if let Ok(local_dir) = env::var("LOCALAPPDATA") {
             base_path = Option::Some(Path::new(&local_dir).to_path_buf())
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -34,13 +34,13 @@ pub struct State {
 fn path() -> Option<PathBuf> {
     // [tag:state_path_has_parent]
     dirs::data_local_dir()
-        .map(|path| path.join("docuum/state.yml"))
         .or_else(|| {
             // In the `mcr.microsoft.com/windows/nanoserver` Docker image, `dirs::data_local_dir()`
             // returns `None` (see https://github.com/dirs-dev/dirs-rs/issues/34 for details). So
             // we fall back to the value of the `LOCALAPPDATA` environment variable in that case.
             env::var("LOCALAPPDATA").ok().map(Into::into)
         })
+        .map(|path| path.join("docuum/state.yml"))
 }
 
 // Return the state in which the program starts, if no state was loaded from disk.

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,7 +5,7 @@ use std::{
     env,
     fs::{create_dir_all, read_to_string},
     io::{self, Write},
-    path::{Path, PathBuf},
+    path::PathBuf,
     time::Duration,
 };
 use tempfile::NamedTempFile;


### PR DESCRIPTION
Use `LOCALAPPDATA` env on windows as otherwise we get errors on windows nano server 😕 

**Status:** Ready

**Fixes:**  fixes #162
