### PR TITLE
For #164: Added systemd service definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,32 @@ docker run \
   stephanmisc/docuum --threshold '15 GB'
 ```
 
+### Running Docuum in a Docker container as a [systemd](https://www.freedesktop.org/wiki/Software/systemd/) service
+
+In [systemd](https://www.freedesktop.org/wiki/Software/systemd/) a `service` can be defined as a file like `/etc/systemd/system/docuum.service` with the following content:
+
+```properties
+[Unit]
+Description=Docuum
+After=docker.service
+Requires=docker.service
+
+[Service]
+Environment="DOCUUM_THRESHOLD=15 GB"
+ExecStart=/usr/bin/docker run \
+    --init \
+    --tty \
+    --rm \
+    --name docuum \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    --volume docuum:/root \
+    stephanmisc/docuum \
+    --threshold ${DOCUUM_THRESHOLD}
+
+[Install]
+WantedBy=multi-user.target
+```
+
 ### Installation on macOS or Linux (x86-64)
 
 If you're running macOS or Linux on an x86-64 CPU, you can install Docuum with this command:

--- a/README.md
+++ b/README.md
@@ -24,47 +24,15 @@ Docuum also respects the parent-child relationships between images. In particula
 
 ## Usage
 
-Docuum is meant to be started once and run forever, rather than as a cron job. Once Docuum is [installed](#installation), you can run it from the command line as follows:
+Once Docuum is [installed](#installation), you can run it manually from the command line as follows:
 
 ```sh
 $ docuum --threshold '30 GB'
 ```
 
-Then you can use `Ctrl`+`C` to stop it.
+Docuum will then start listening for Docker events. You can use `Ctrl`+`C` to stop it.
 
-However, you probably want to run Docuum as a [daemon](https://en.wikipedia.org/wiki/Daemon_\(computing\)), e.g., with [launchd](https://www.launchd.info/), [systemd](https://www.freedesktop.org/wiki/Software/systemd/), etc. You may consult your operating system documentation for instructions on how to do that. On macOS, for example, you can create a file (owned by root) called `/Library/LaunchDaemons/local.docuum.plist` with the following:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-    <dict>
-        <key>Label</key>
-        <string>local.docuum</string>
-        <key>Program</key>
-        <string>/usr/local/bin/docuum</string>
-        <key>ProgramArguments</key>
-        <array>
-            <string>/usr/local/bin/docuum</string>
-            <string>--threshold</string>
-            <string>10 GB</string>
-        </array>
-        <key>StandardOutPath</key>
-        <string>/var/log/docuum.log</string>
-        <key>StandardErrorPath</key>
-        <string>/var/log/docuum.log</string>
-        <key>EnvironmentVariables</key>
-        <dict>
-            <key>PATH</key>
-            <string>/bin:/usr/bin:/usr/local/bin</string>
-        </dict>
-        <key>KeepAlive</key>
-        <true/>
-    </dict>
-</plist>
-```
-
-Now Docuum will start automatically when you restart your machine, and the logs can be found at `/var/log/docuum.log`. If you do not wish to restart your machine, you can run `sudo launchctl load /Library/LaunchDaemons/local.docuum.plist` to start the daemon.
+You probably want to run Docuum as a [daemon](https://en.wikipedia.org/wiki/Daemon_\(computing\)), e.g., with [launchd](https://www.launchd.info/), [systemd](https://www.freedesktop.org/wiki/Software/systemd/), etc. See the [Configuring your operating system to run the binary as a service](#configuring-your-operating-system-to-run-the-binary-as-a-service) section below for instructions.
 
 Here are the supported command-line options:
 
@@ -80,7 +48,7 @@ OPTIONS:
             Prevents deletion of images for which repository:tag matches <REGEX>
 
     -t, --threshold <THRESHOLD>
-            Sets the maximum amount of space to be used for Docker images (default: 10 GB)
+            Sets the maximum amount of space to be used for Docker images (default: 15 GB)
 
     -v, --version
             Prints version information
@@ -90,61 +58,14 @@ The `--threshold` flag accepts [multiple representations](https://docs.rs/byte-u
 
 ## Installation
 
-### Running Docuum in a Docker container on macOS or Linux (x86-64)
+Installation consists of two steps:
 
-If you prefer not to install Docuum on your system and you're running macOS or Linux on an x86-64 CPU, you can run it in a container. To run it in the foreground, you can use a command like the following:
+1. Installing the binary
+2. Configuring your operating system to run the binary as a service
 
-```sh
-docker run \
-  --init \
-  --rm \
-  --tty \
-  --name docuum \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume docuum:/root \
-  stephanmisc/docuum --threshold '15 GB'
-```
+### Installing the binary
 
-To run it in the background:
-
-```sh
-docker run \
-  --detach \
-  --init \
-  --rm \
-  --name docuum \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
-  --volume docuum:/root \
-  stephanmisc/docuum --threshold '15 GB'
-```
-
-### Running Docuum in a Docker container as a [systemd](https://www.freedesktop.org/wiki/Software/systemd/) service
-
-In [systemd](https://www.freedesktop.org/wiki/Software/systemd/) a `service` can be defined as a file like `/etc/systemd/system/docuum.service` with the following content:
-
-```properties
-[Unit]
-Description=Docuum
-After=docker.service
-Requires=docker.service
-
-[Service]
-Environment="DOCUUM_THRESHOLD=15 GB"
-ExecStart=/usr/bin/docker run \
-    --init \
-    --tty \
-    --rm \
-    --name docuum \
-    --volume /var/run/docker.sock:/var/run/docker.sock \
-    --volume docuum:/root \
-    stephanmisc/docuum \
-    --threshold ${DOCUUM_THRESHOLD}
-
-[Install]
-WantedBy=multi-user.target
-```
-
-### Installation on macOS or Linux (x86-64)
+#### Installation on macOS or Linux (x86-64)
 
 If you're running macOS or Linux on an x86-64 CPU, you can install Docuum with this command:
 
@@ -167,13 +88,13 @@ curl https://raw.githubusercontent.com/stepchowfun/docuum/main/install.sh -LSfs 
 
 If you prefer not to use this installation method, you can download the binary from the [releases page](https://github.com/stepchowfun/docuum/releases), make it executable (e.g., with `chmod`), and place it in some directory in your [`PATH`](https://en.wikipedia.org/wiki/PATH_\(variable\)) (e.g., `/usr/local/bin`).
 
-### Installation on Windows (x86-64)
+#### Installation on Windows (x86-64)
 
 If you're running Windows on an x86-64 CPU, download the latest binary from the [releases page](https://github.com/stepchowfun/docuum/releases) and rename it to `docuum` (or `docuum.exe` if you have file extensions visible). Create a directory called `Docuum` in your `%PROGRAMFILES%` directory (e.g., `C:\Program Files\Docuum`), and place the renamed binary in there. Then, in the "Advanced" tab of the "System Properties" section of "Control Panel", click on "Environment Variables..." and add the full path to the new `Docuum` directory to the `PATH` variable under "System variables". Note that the `Program Files` directory might have a different name if Windows is configured for language other than English.
 
 To update to an existing installation, simply replace the existing binary.
 
-### Installation with Cargo
+#### Installation with Cargo
 
 If you have [Cargo](https://doc.rust-lang.org/cargo/), you can install Docuum as follows:
 
@@ -182,6 +103,95 @@ cargo install docuum
 ```
 
 You can run that command with `--force` to update an existing installation.
+
+#### Running Docuum in a Docker container on macOS or Linux (x86-64)
+
+If you prefer not to install Docuum on your system and you're running macOS or Linux on an x86-64 CPU, you can run it in a container:
+
+```sh
+docker run \
+  --init \
+  --rm \
+  --tty \
+  --name docuum \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume docuum:/root \
+  stephanmisc/docuum --threshold '15 GB'
+```
+
+### Configuring your operating system to run the binary as a service
+
+You may consult your operating system documentation for instructions on how set up a service. Instructions are provided below for macOS and Linux.
+
+#### Creating a [launchd](https://www.launchd.info/) service on macOS
+
+Create a file (owned by root) called `/Library/LaunchDaemons/local.docuum.plist` with the following contents, adjusting the arguments as needed:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>local.docuum</string>
+        <key>Program</key>
+        <string>/usr/local/bin/docuum</string>
+        <key>ProgramArguments</key>
+        <array>
+            <string>/usr/local/bin/docuum</string>
+            <string>--threshold</string>
+            <string>15 GB</string>
+        </array>
+        <key>StandardOutPath</key>
+        <string>/var/log/docuum.log</string>
+        <key>StandardErrorPath</key>
+        <string>/var/log/docuum.log</string>
+        <key>EnvironmentVariables</key>
+        <dict>
+            <key>PATH</key>
+            <string>/bin:/usr/bin:/usr/local/bin</string>
+        </dict>
+        <key>KeepAlive</key>
+        <true/>
+    </dict>
+</plist>
+```
+
+Now Docuum will start automatically when you restart your machine, and the logs can be found at `/var/log/docuum.log`. If you do not wish to restart your machine, you can run `sudo launchctl load /Library/LaunchDaemons/local.docuum.plist` to start the daemon immediately.
+
+#### Creating a [systemd](https://www.freedesktop.org/wiki/Software/systemd/) service on Linux
+
+Create a file (owned by root) called `/etc/systemd/system/docuum.service` with the following contents, adjusting the arguments as needed:
+
+```ini
+[Unit]
+Description=Docuum
+After=docker.service
+Wants=docker.service
+
+[Service]
+Environment='THRESHOLD=15 GB'
+ExecStart=/usr/local/bin/docuum --threshold ${THRESHOLD}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+If you prefer not to install Docuum on your system and would rather run it as a Docker container, replace the `ExecStart` line with the following, adjusting the arguments as needed:
+
+```ini
+ExecStart=/usr/bin/docker run \
+  --init \
+  --rm \
+  --tty \
+  --name docuum \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume docuum:/root \
+  stephanmisc/docuum --threshold ${THRESHOLD}
+```
+
+In either case, run `sudo systemctl enable docuum --now` to enable and start the service.
 
 ## Requirements
 


### PR DESCRIPTION
I added the requested section below the docker because it somehow did not fit below the macos daemon example because docker was added later on and I did not try it natively with `docuum`.

Please feel free to move the sections if you see fit
