### PR TITLE
Closes #164: Documented threshold representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ OPTIONS:
             Prints version information
 ```
 
-The threshold parameter accepts [multiple representations](https://docs.rs/byte-unit/4.0.12/byte_unit/struct.Byte.html#examples-2) like `10 GB`, `10 GiB` or `10GB`.
+The threshold parameter accepts [multiple representations](https://docs.rs/byte-unit/4.0.12/byte_unit/struct.Byte.html#examples-2), like `10 GB`, `10 GiB`, or `10GB`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ OPTIONS:
             Prints version information
 ```
 
+The threshold parameter accepts [multiple representations](https://docs.rs/byte-unit/4.0.12/byte_unit/struct.Byte.html#examples-2) like `10 GB`, `10 GiB` or `10GB`.
+
 ## Installation
 
 ### Running Docuum in a Docker container on macOS or Linux (x86-64)


### PR DESCRIPTION
I linked the original rust examples because they even showed very unique possibilities but have shown only, imho, the most common usecases.