### PR TITLE
Use a more robust way to determine the images in use and release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.20.0] - 2021-07-15
+## [0.20.1] - 2021-08-02
+
+### Changed
+- Docuum now uses a more robust way to determine the images that are currently in use by containers.
+
+## [0.20.0] - 2021-08-02
 
 ### Added
 - Added the `--keep` flag to prevent Docuum from deleting certain images.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "atty",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images."


### PR DESCRIPTION
Use a more robust way to determine the images in use and release v0.20.1.

**Status:** Ready

**Fixes:** N/A
