### PR TITLE
Increase the interval that Docuum sleeps between attempts to connect to the Docker event stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.3] - 2021-08-08
+
+### Changed
+- When Docker is not running, Docuum now restarts every 5 seconds instead of every second.
+
 ## [0.20.2] - 2021-08-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "atty",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.20.2"
+version = "0.20.3"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2018"
 description = "LRU eviction of Docker images."

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -20,7 +20,7 @@ DOCUUM_PID="$!"
 # several times at a 1 second interval.
 wait_for_docuum() {
   echo 'Waiting for Docuum to sleep…'
-  for _ in {0..4}; do
+  for _ in {0..7}; do
     sleep 1
     while [[ "$(awk '{ print $3 }' /proc/$DOCUUM_PID/stat)" != 'S' ]]; do
       sleep 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,8 +177,8 @@ fn main() {
     loop {
         if let Err(e) = run(&settings, &mut state, &mut first_run) {
             error!("{}", e);
-            info!("Restarting\u{2026}");
-            sleep(Duration::from_secs(1));
+            info!("Retrying in 5 seconds\u{2026}");
+            sleep(Duration::from_secs(5));
         }
     }
 }


### PR DESCRIPTION
Increase the interval that Docuum sleeps between attempts to connect to the Docker event stream. Retrying every second seems unnecessary for Docuum.

**Status:** Ready

**Fixes:** N/A