### PR TITLE
Don't prefix shell commands with $

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Docuum also respects the parent-child relationships between images. In particula
 Once Docuum is [installed](#installation-instructions), you can run it manually from the command line as follows:
 
 ```sh
-$ docuum --threshold '10 GB'
+docuum --threshold '10 GB'
 ```
 
 Docuum will then start listening for Docker events. You can use `Ctrl`+`C` to stop it.


### PR DESCRIPTION
Don't prefix shell commands with $.

**Status:** Ready

**Fixes:** N/A
