### PR TITLE
Always install a specific version of Rust before invoking `cargo`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
         # Make Bash not silently ignore errors.
         set -euo pipefail
 
+        # Install the appropriate version of Rust.
+        rustup toolchain install 1.56.0 # [ref:rust_1_56_0]
+        rustup default 1.56.0 # [ref:rust_1_56_0]
+
         # Fetch the program version.
         VERSION="$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"
 


### PR DESCRIPTION
Always install a specific version of Rust before invoking `cargo`.

**Status:** Ready

**Fixes:** N/A