### PR TITLE
Don't fail when encountering images with timestamps earlier than the UNIX epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.5] - 2022-03-06
+
+### Fixed
+- Docuum now works with images produced by `kaniko --reproducible`, which produces images with timestamps earlier than the UNIX epoch.
+
 ## [0.20.4] - 2021-12-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.20.4"
+version = "0.20.5"
 dependencies = [
  "atty",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.20.4"
+version = "0.20.5"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "LRU eviction of Docker images."


### PR DESCRIPTION
Don't fail when encountering images with timestamps earlier than the UNIX epoch.

**Status:** Ready

**Fixes:** https://github.com/stepchowfun/docuum/issues/213