### PR TITLE
Add support for percentage-based thresholds on Linux and release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2022-04-05
+
+### Added
+- On Linux, Docuum now supports percentage-based thresholds such as `--threshold '50%'` in addition to absolute thresholds like `--threshold '10 GB'`.
+
 ## [0.20.5] - 2022-03-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.20.5"
+version = "0.21.0"
 dependencies = [
  "atty",
  "byte-unit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.20.5"
+version = "0.21.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "LRU eviction of Docker images."


### PR DESCRIPTION
Add support for percentage-based thresholds on Linux and release v0.21.0.

**Status:** Ready

**Fixes:** N/A