### PR TITLE
Remove alpine minor version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # A minimal base image
-FROM alpine:3.15.0
+FROM alpine:3.15
 
 # Install the Docker CLI.
 RUN apk add --no-cache docker-cli


### PR DESCRIPTION
Otherwise we will be stuck on the old (and now vulnerable) version. 
This way, it should use the latest tag when you make a new release build.

A clear description of the change.

**Status:** Ready / In development

**Fixes:** Link to issue (if applicable)
