### PR TITLE
Disable unnecessary regex and env_logger features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,9 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
- "humantime",
  "log",
- "regex",
  "termcolor",
 ]
 
@@ -234,12 +223,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "itoa"
@@ -273,12 +256,6 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "memchr"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
@@ -447,8 +424,6 @@ version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ scopeguard = "1"
 serde_json = "1.0"
 serde_yaml = "0.8"
 tempfile = "3"
-regex = "1.5.5"
+regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-perl"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sysinfo = "0.23.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ byte-unit = "4"
 chrono = "0.4"
 colored = "2"
 dirs = "3"
-env_logger = "0.8"
+env_logger = { version = "0.8", default-features = false, features = ["termcolor", "atty"] }
 log = "0.4"
 scopeguard = "1"
 serde_json = "1.0"


### PR DESCRIPTION
This reduces the size of the docuum binary by ~32 %.

With this applied, `docuum` has 1.3 MiB when built with `lto = true`, `panic = "abort"`, `opt-level = "s"` on Alpine Linux x86_64 (with dynamically linked libc).

**Status:** Ready
