### PR TITLE
Add deletion-chunk-size parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 # don't ignore /.git/ since Git already ignores it.
 /artifacts/
 /target/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 # don't ignore /.git/ since Git already ignores it.
 /artifacts/
 /target/
-.idea

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ USAGE:
 
 OPTIONS:
     -d, --deletion-chunk-size <DELETION CHUNK SIZE>
-            Removes specified quantity of images before checking disk usage (default: 1)
+            Removes specified quantity of images at a time (default: 1)
+
     -h, --help
             Prints help information
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ USAGE:
     docuum
 
 OPTIONS:
+    -d, --deletion-chunk-size <DELETION CHUNK SIZE>
+            Removes specified quantity of images before checking disk usage (default: 1)
     -h, --help
             Prints help information
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,7 +196,7 @@ fn settings() -> io::Result<Settings> {
                 .number_of_values(1)
                 .help(&format!(
                     "Removes specified quantity of images at a time (default: {})",
-                    DEFAULT_DELETION_CHUNK_SIZE
+                    DEFAULT_DELETION_CHUNK_SIZE,
                 )),
         )
         .get_matches();

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 // Defaults
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Debug;
 const DEFAULT_THRESHOLD: &str = "10 GB";
-const DEFAULT_DELETION_CHUNK_SIZE: i32 = 1;
+const DEFAULT_DELETION_CHUNK_SIZE: usize = 1;
 
 // Command-line argument and option names
 const THRESHOLD_OPTION: &str = "threshold";
@@ -110,7 +110,7 @@ impl Threshold {
 pub struct Settings {
     threshold: Threshold,
     keep: Option<RegexSet>,
-    del_chunk_size: i32,
+    deletion_chunk_size: usize,
 }
 
 // Set up the logger.
@@ -217,12 +217,16 @@ fn settings() -> io::Result<Settings> {
         None => None,
     };
 
-    let del_chunk_size = match matches.value_of(DELETION_CHUNK_SIZE_OPTION) {
-        Some(v) => v.parse::<i32>().unwrap(),
+    // Determine how many images to delete at once.
+    let deletion_chunk_size = match matches.value_of(DELETION_CHUNK_SIZE_OPTION) {
+        Some(v) => match v.parse::<usize>() {
+            Ok(chunk_size) => { chunk_size }
+            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e))
+        },
         None => DEFAULT_DELETION_CHUNK_SIZE,
     };
 
-    Ok(Settings { threshold, keep, del_chunk_size })
+    Ok(Settings { threshold, keep, deletion_chunk_size })
 }
 
 // Let the fun begin!

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,12 +222,16 @@ fn settings() -> io::Result<Settings> {
     let deletion_chunk_size = match matches.value_of(DELETION_CHUNK_SIZE_OPTION) {
         Some(v) => match v.parse::<usize>() {
             Ok(chunk_size) => chunk_size,
-            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e))
+            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
         },
         None => DEFAULT_DELETION_CHUNK_SIZE,
     };
 
-    Ok(Settings { threshold, keep, deletion_chunk_size })
+    Ok(Settings {
+        threshold,
+        keep,
+        deletion_chunk_size,
+    })
 }
 
 // Let the fun begin!

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,14 +30,14 @@ extern crate log;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // Defaults
+const DEFAULT_DELETION_CHUNK_SIZE: usize = 1;
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Debug;
 const DEFAULT_THRESHOLD: &str = "10 GB";
-const DEFAULT_DELETION_CHUNK_SIZE: usize = 1;
 
 // Command-line argument and option names
-const THRESHOLD_OPTION: &str = "threshold";
-const KEEP_OPTION: &str = "keep";
 const DELETION_CHUNK_SIZE_OPTION: &str = "deletion-chunk-size";
+const KEEP_OPTION: &str = "keep";
+const THRESHOLD_OPTION: &str = "threshold";
 
 // Size threshold argument, absolute or relative to filesystem size
 #[derive(Copy, Clone)]
@@ -193,8 +193,9 @@ fn settings() -> io::Result<Settings> {
                 .value_name("DELETION CHUNK SIZE")
                 .short("d")
                 .long(DELETION_CHUNK_SIZE_OPTION)
+                .number_of_values(1)
                 .help(&format!(
-                    "Removes specified quantity of images before checking disk usage (default: {})",
+                    "Removes specified quantity of images at a time (default: {})",
                     DEFAULT_DELETION_CHUNK_SIZE
                 )),
         )
@@ -220,7 +221,7 @@ fn settings() -> io::Result<Settings> {
     // Determine how many images to delete at once.
     let deletion_chunk_size = match matches.value_of(DELETION_CHUNK_SIZE_OPTION) {
         Some(v) => match v.parse::<usize>() {
-            Ok(chunk_size) => { chunk_size }
+            Ok(chunk_size) => chunk_size,
             Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e))
         },
         None => DEFAULT_DELETION_CHUNK_SIZE,

--- a/src/run.rs
+++ b/src/run.rs
@@ -652,7 +652,8 @@ fn vacuum(
             for repository_tag in &image_node.image_record.repository_tags {
                 if regex_set.is_match(&format!(
                     "{}:{}",
-                    repository_tag.repository, repository_tag.tag,
+                    repository_tag.repository,
+                    repository_tag.tag,
                 )) {
                     debug!(
                         "Ignored image {} due to the {} flag.",

--- a/src/run.rs
+++ b/src/run.rs
@@ -625,6 +625,7 @@ fn vacuum(
     first_run: bool,
     threshold: Byte,
     keep: &Option<RegexSet>,
+    del_chunk_size: i32,
 ) -> io::Result<()> {
     // Find all images.
     let image_records = list_image_records(state)?;
@@ -678,14 +679,16 @@ fn vacuum(
         );
 
         // Start deleting images, beginning with the least recently used.
-        for (image_id, _) in sorted_image_nodes {
-            // Delete the image.
-            if let Err(error) = delete_image(image_id) {
-                // The deletion failed. Just log the error and proceed.
-                error!("{}", error);
-            } else {
-                // Forget about the deleted image.
-                deleted_image_ids.insert(image_id.clone());
+        for image_ids in sorted_image_nodes.chunks(usize::try_from(del_chunk_size).unwrap()) {
+            for (image_id, _) in image_ids {
+                // Delete the image.
+                if let Err(error) = delete_image(image_id) {
+                    // The deletion failed. Just log the error and proceed.
+                    error!("{}", error);
+                } else {
+                    // Forget about the deleted image.
+                    deleted_image_ids.insert(image_id.clone());
+                }
             }
 
             // Break if we're within the threshold.
@@ -709,7 +712,7 @@ fn vacuum(
 
     // Update the state.
     state.images.clear();
-    for (image_id, image_node) in polyforest {
+    for (image_id, image_node) in &polyforest {
         if !deleted_image_ids.contains(&image_id) {
             state.images.insert(
                 image_id.clone(),
@@ -747,7 +750,7 @@ pub fn run(settings: &Settings, state: &mut State, first_run: &mut bool) -> io::
     info!("Performing an initial vacuum on startup\u{2026}");
 
     // Run the main vacuum logic.
-    vacuum(state, *first_run, threshold, &settings.keep)?;
+    vacuum(state, *first_run, threshold, &settings.keep, settings.del_chunk_size)?;
     state::save(state)?;
     *first_run = false;
 
@@ -824,7 +827,7 @@ pub fn run(settings: &Settings, state: &mut State, first_run: &mut bool) -> io::
         touch_image(state, &image_id, true)?;
 
         // Run the main vacuum logic.
-        vacuum(state, *first_run, threshold, &settings.keep)?;
+        vacuum(state, *first_run, threshold, &settings.keep, settings.del_chunk_size)?;
 
         // Persist the state.
         state::save(state)?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -652,8 +652,7 @@ fn vacuum(
             for repository_tag in &image_node.image_record.repository_tags {
                 if regex_set.is_match(&format!(
                     "{}:{}",
-                    repository_tag.repository,
-                    repository_tag.tag,
+                    repository_tag.repository, repository_tag.tag,
                 )) {
                     debug!(
                         "Ignored image {} due to the {} flag.",
@@ -750,7 +749,13 @@ pub fn run(settings: &Settings, state: &mut State, first_run: &mut bool) -> io::
     info!("Performing an initial vacuum on startup\u{2026}");
 
     // Run the main vacuum logic.
-    vacuum(state, *first_run, threshold, &settings.keep, settings.deletion_chunk_size)?;
+    vacuum(
+        state,
+        *first_run,
+        threshold,
+        &settings.keep,
+        settings.deletion_chunk_size,
+    )?;
     state::save(state)?;
     *first_run = false;
 
@@ -827,7 +832,13 @@ pub fn run(settings: &Settings, state: &mut State, first_run: &mut bool) -> io::
         touch_image(state, &image_id, true)?;
 
         // Run the main vacuum logic.
-        vacuum(state, *first_run, threshold, &settings.keep, settings.deletion_chunk_size)?;
+        vacuum(
+            state,
+            *first_run,
+            threshold,
+            &settings.keep,
+            settings.deletion_chunk_size,
+        )?;
 
         // Persist the state.
         state::save(state)?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -625,7 +625,7 @@ fn vacuum(
     first_run: bool,
     threshold: Byte,
     keep: &Option<RegexSet>,
-    del_chunk_size: i32,
+    deletion_chunk_size: usize,
 ) -> io::Result<()> {
     // Find all images.
     let image_records = list_image_records(state)?;
@@ -679,7 +679,7 @@ fn vacuum(
         );
 
         // Start deleting images, beginning with the least recently used.
-        for image_ids in sorted_image_nodes.chunks(usize::try_from(del_chunk_size).unwrap()) {
+        for image_ids in sorted_image_nodes.chunks_mut(deletion_chunk_size) {
             for (image_id, _) in image_ids {
                 // Delete the image.
                 if let Err(error) = delete_image(image_id) {
@@ -712,7 +712,7 @@ fn vacuum(
 
     // Update the state.
     state.images.clear();
-    for (image_id, image_node) in &polyforest {
+    for (image_id, image_node) in polyforest {
         if !deleted_image_ids.contains(&image_id) {
             state.images.insert(
                 image_id.clone(),
@@ -750,7 +750,7 @@ pub fn run(settings: &Settings, state: &mut State, first_run: &mut bool) -> io::
     info!("Performing an initial vacuum on startup\u{2026}");
 
     // Run the main vacuum logic.
-    vacuum(state, *first_run, threshold, &settings.keep, settings.del_chunk_size)?;
+    vacuum(state, *first_run, threshold, &settings.keep, settings.deletion_chunk_size)?;
     state::save(state)?;
     *first_run = false;
 
@@ -827,7 +827,7 @@ pub fn run(settings: &Settings, state: &mut State, first_run: &mut bool) -> io::
         touch_image(state, &image_id, true)?;
 
         // Run the main vacuum logic.
-        vacuum(state, *first_run, threshold, &settings.keep, settings.del_chunk_size)?;
+        vacuum(state, *first_run, threshold, &settings.keep, settings.deletion_chunk_size)?;
 
         // Persist the state.
         state::save(state)?;


### PR DESCRIPTION
Add a parameter to specify how many images the Docuum should delete before calling `docker system df`

**Status:** Ready

**Fixes:** [238](https://github.com/stepchowfun/docuum/issues/238)

