### PR TITLE
Only run vacuum when a new image is added to the cache.

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -449,17 +449,17 @@ fn touch_image(state: &mut State, image_id: &str, verbose: bool) -> io::Result<b
     // Get the current timestamp.
     match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(duration) => {
-            let is_new_image = !state.images.contains_key(image_id);
-
             // Store the image metadata in the state.
-            state.images.insert(
-                image_id.to_owned(),
-                state::Image {
-                    parent_id: parent_id(state, image_id)?,
-                    last_used_since_epoch: duration,
-                },
-            );
-            Ok(is_new_image)
+            Ok(state
+                .images
+                .insert(
+                    image_id.to_owned(),
+                    state::Image {
+                        parent_id: parent_id(state, image_id)?,
+                        last_used_since_epoch: duration,
+                    },
+                )
+                .is_none())
         }
         Err(error) => Err(io::Error::new(
             io::ErrorKind::Other,
@@ -655,7 +655,8 @@ fn vacuum(
             for repository_tag in &image_node.image_record.repository_tags {
                 if regex_set.is_match(&format!(
                     "{}:{}",
-                    repository_tag.repository, repository_tag.tag,
+                    repository_tag.repository,
+                    repository_tag.tag,
                 )) {
                     debug!(
                         "Ignored image {} due to the {} flag.",


### PR DESCRIPTION
Otherwise there should be no need to start evicting. This reduces the load on moby (docker-daemon) via less `docker system df` calls as well as improving the performance of docuum.

I ran into issue #244 today on a server with high churn (but well cached images). This caused dockerd performance issues. 

Below are some flamegraphs of dockerd before and after this fix. You can see the before is spending a majority of its time answering getDiskUsage calls while the one from after this fix is spent doing container operations.

Before PR:
![moby_flamegraph](https://github.com/stepchowfun/docuum/assets/2242141/f1922f92-e540-45dc-ab45-21d1366c73a7)

After PR:
![moby_docuum_fix](https://github.com/stepchowfun/docuum/assets/2242141/22a4ab05-4e8e-4c6c-8885-18d372efc2fe)


**Status:** Ready

**Fixes:** [#244](https://github.com/stepchowfun/docuum/issues/244)
