### PR TITLE
Update the way lints are configured to use Rust's new `manifest-lint` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ homepage = "https://github.com/stepchowfun/docuum"
 repository = "https://github.com/stepchowfun/docuum"
 readme = "README.md"
 
+[lints]
+clippy.all = "deny"
+clippy.pedantic = "deny"
+rust.warnings = "deny"
+
 [dependencies]
 atty = "0.2"
 byte-unit = "4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic, warnings)]
-
 mod format;
 mod run;
 mod state;


### PR DESCRIPTION
Update the way lints are configured to use Rust's new `manifest-lint` feature.

**Status:** Ready

**Fixes:** N/A