### PR TITLE
Allow running the script one time

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ OPTIONS:
     -t, --threshold <THRESHOLD>
             Sets the maximum amount of space to be used for Docker images (default: 10 GB)
 
+    -s, --single_run <SINGLE_RUN>
+            Exits after first cleanup and doesn't wait for any more docker events (default: false)
+
     -v, --version
             Prints version information
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,11 +31,13 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_DELETION_CHUNK_SIZE: usize = 1;
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Debug;
 const DEFAULT_THRESHOLD: &str = "10 GB";
+const DEFAULT_SINGLE_RUN: bool = false;
 
 // Command-line argument and option names
 const DELETION_CHUNK_SIZE_OPTION: &str = "deletion-chunk-size";
 const KEEP_OPTION: &str = "keep";
 const THRESHOLD_OPTION: &str = "threshold";
+const SINGLE_RUN: &str = "single-run";
 
 // Size threshold argument, absolute or relative to filesystem size
 #[derive(Copy, Clone)]
@@ -109,6 +111,7 @@ pub struct Settings {
     threshold: Threshold,
     keep: Option<RegexSet>,
     deletion_chunk_size: usize,
+    single_run: bool,
 }
 
 // Set up the logger.
@@ -197,6 +200,18 @@ fn settings() -> io::Result<Settings> {
                         (default: {DEFAULT_DELETION_CHUNK_SIZE})",
                 )),
         )
+        .arg(
+            Arg::with_name(SINGLE_RUN)
+                .value_name("SINGLE RUN")
+                .short("s")
+                .long(SINGLE_RUN)
+                .number_of_values(1)
+                .takes_value(false)
+                .help(&format!(
+                    "Run once then exit \
+                    (default: {DEFAULT_SINGLE_RUN})",
+                )),
+        )
         .get_matches();
 
     // Read the threshold.
@@ -225,10 +240,14 @@ fn settings() -> io::Result<Settings> {
         None => DEFAULT_DELETION_CHUNK_SIZE,
     };
 
+    // Determine if we should do a single run or a loop.
+    let single_run = matches.is_present(SINGLE_RUN);
+
     Ok(Settings {
         threshold,
         keep,
         deletion_chunk_size,
+        single_run,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ fn settings() -> io::Result<Settings> {
                 .number_of_values(1)
                 .takes_value(false)
                 .help(&format!(
-                    "Run once then exit \
+                    "Exits after first cleanup and doesn't wait for any more docker events \
                     (default: {DEFAULT_SINGLE_RUN})",
                 )),
         )

--- a/src/run.rs
+++ b/src/run.rs
@@ -15,7 +15,7 @@ use {
         io::{self, BufRead, BufReader},
         mem::drop,
         ops::Deref,
-        process::{Command, Stdio},
+        process::{exit, Command, Stdio},
         time::{Duration, SystemTime, UNIX_EPOCH},
     },
 };
@@ -655,8 +655,7 @@ fn vacuum(
             for repository_tag in &image_node.image_record.repository_tags {
                 if regex_set.is_match(&format!(
                     "{}:{}",
-                    repository_tag.repository,
-                    repository_tag.tag,
+                    repository_tag.repository, repository_tag.tag,
                 )) {
                     debug!(
                         "Ignored image {} due to the {} flag.",
@@ -762,6 +761,11 @@ pub fn run(settings: &Settings, state: &mut State, first_run: &mut bool) -> io::
     )?;
     state::save(state)?;
     *first_run = false;
+
+    if settings.single_run {
+        info!("Single run. Exiting \u{2026}");
+        exit(0);
+    }
 
     // Spawn `docker events --format '{{json .}}'`.
     let mut child = guard(


### PR DESCRIPTION
We have been using docuum for more than a year now and we are trying to optimize and avoid job errors like missing docker layers. This can happen rarely when docuum starts to remove some layers and the current gitlab job is trying to use the docker image needing that layer ( at least that's my interpretation ). 
Thus we are switching to a per runner maintenance mode that runs all the cleanups only on demand so the docuum nssm service would interfere.
Maybe this is useful for others too.
Best Regards,
Costin

**Status:** Ready


