### PR TITLE
Add a flag to exit immediately on error instead of retrying

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ Here are the supported command-line options:
 
 ```
 USAGE:
-    docuum
+    docuum [OPTIONS]
 
 OPTIONS:
     -d, --deletion-chunk-size <DELETION CHUNK SIZE>
             Removes specified quantity of images at a time (default: 1)
+
+    -f, --fail-fast
+            Exits immediately on error instead of retrying
 
     -h, --help
             Prints help information

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ OPTIONS:
     -d, --deletion-chunk-size <DELETION CHUNK SIZE>
             Removes specified quantity of images at a time (default: 1)
 
-    -f, --fail-fast
-            Exits immediately on error instead of retrying
+    -f, --fail-on-docker-exit
+            Exits immediately on docker exit instead of restarting
 
     -h, --help
             Prints help information

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ const DEFAULT_THRESHOLD: &str = "10 GB";
 const DELETION_CHUNK_SIZE_OPTION: &str = "deletion-chunk-size";
 const KEEP_OPTION: &str = "keep";
 const THRESHOLD_OPTION: &str = "threshold";
-const FAIL_FAST: &str = "fail-fast";
+const FAIL_ON_DOCKER_EXIT: &str = "fail-on-docker-exit";
 
 // Size threshold argument, absolute or relative to filesystem size
 #[derive(Copy, Clone)]
@@ -200,10 +200,10 @@ fn settings() -> io::Result<Settings> {
                 )),
         )
         .arg(
-            Arg::with_name(FAIL_FAST)
+            Arg::with_name(FAIL_ON_DOCKER_EXIT)
                 .short("f")
-                .long(FAIL_FAST)
-                .help("Exits immediately on error instead of retrying"),
+                .long(FAIL_ON_DOCKER_EXIT)
+                .help("Exits immediately on docker exit instead of restarting"),
         )
         .get_matches();
 
@@ -234,7 +234,7 @@ fn settings() -> io::Result<Settings> {
     };
 
     // Determine whether to exit immediately on error.
-    let fail_fast = matches.is_present(FAIL_FAST);
+    let fail_fast = matches.is_present(FAIL_ON_DOCKER_EXIT);
 
     Ok(Settings {
         threshold,
@@ -282,7 +282,7 @@ fn main() {
             error!("{}", e);
             // If we're in fail-fast mode, exit immediately.
             if settings.fail_fast {
-                error!("Exiting due to --fail-fast");
+                error!("Exiting due to --fail-on-docker-exit");
                 exit(1);
             // Otherwise, retry after a short delay.
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ const DEFAULT_THRESHOLD: &str = "10 GB";
 const DELETION_CHUNK_SIZE_OPTION: &str = "deletion-chunk-size";
 const KEEP_OPTION: &str = "keep";
 const THRESHOLD_OPTION: &str = "threshold";
+const FAIL_FAST: &str = "fail-fast";
 
 // Size threshold argument, absolute or relative to filesystem size
 #[derive(Copy, Clone)]
@@ -109,6 +110,7 @@ pub struct Settings {
     threshold: Threshold,
     keep: Option<RegexSet>,
     deletion_chunk_size: usize,
+    fail_fast: bool,
 }
 
 // Set up the logger.
@@ -197,6 +199,12 @@ fn settings() -> io::Result<Settings> {
                         (default: {DEFAULT_DELETION_CHUNK_SIZE})",
                 )),
         )
+        .arg(
+            Arg::with_name(FAIL_FAST)
+                .short("f")
+                .long(FAIL_FAST)
+                .help("Prevents restarting subprocess"),
+        )
         .get_matches();
 
     // Read the threshold.
@@ -225,10 +233,13 @@ fn settings() -> io::Result<Settings> {
         None => DEFAULT_DELETION_CHUNK_SIZE,
     };
 
+    let fail_fast = matches.is_present(FAIL_FAST);
+
     Ok(Settings {
         threshold,
         keep,
         deletion_chunk_size,
+        fail_fast,
     })
 }
 
@@ -268,6 +279,9 @@ fn main() {
     loop {
         if let Err(e) = run(&settings, &mut state, &mut first_run) {
             error!("{}", e);
+            if settings.fail_fast {
+                break;
+            }
             info!("Retrying in 5 seconds\u{2026}");
             sleep(Duration::from_secs(5));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,7 @@ fn settings() -> io::Result<Settings> {
         None => DEFAULT_DELETION_CHUNK_SIZE,
     };
 
+    // Determine whether to exit immediately on error.
     let fail_fast = matches.is_present(FAIL_FAST);
 
     Ok(Settings {
@@ -275,13 +276,15 @@ fn main() {
         |state| (state, false),
     );
 
-    // Stream Docker events and vacuum when necessary. Restart if an error occurs.
+    // Stream Docker events and vacuum when necessary.
     loop {
         if let Err(e) = run(&settings, &mut state, &mut first_run) {
             error!("{}", e);
+            // If we're in fail-fast mode, exit immediately.
             if settings.fail_fast {
                 error!("Exiting due to --fail-fast");
                 exit(1);
+            // Otherwise, retry after a short delay.
             } else {
                 error!("Retrying in 5 seconds\u{2026}");
                 sleep(Duration::from_secs(5));

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn settings() -> io::Result<Settings> {
             Arg::with_name(FAIL_FAST)
                 .short("f")
                 .long(FAIL_FAST)
-                .help("Prevents restarting subprocess"),
+                .help("Exits immediately on error instead of retrying"),
         )
         .get_matches();
 
@@ -280,10 +280,12 @@ fn main() {
         if let Err(e) = run(&settings, &mut state, &mut first_run) {
             error!("{}", e);
             if settings.fail_fast {
-                break;
+                error!("Exiting due to --fail-fast");
+                exit(1);
+            } else {
+                error!("Retrying in 5 seconds\u{2026}");
+                sleep(Duration::from_secs(5));
             }
-            info!("Retrying in 5 seconds\u{2026}");
-            sleep(Duration::from_secs(5));
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ pub struct Settings {
     threshold: Threshold,
     keep: Option<RegexSet>,
     deletion_chunk_size: usize,
-    fail_fast: bool,
+    fail_on_docker_exit: bool,
 }
 
 // Set up the logger.
@@ -240,7 +240,7 @@ fn settings() -> io::Result<Settings> {
         threshold,
         keep,
         deletion_chunk_size,
-        fail_fast,
+        fail_on_docker_exit: fail_fast,
     })
 }
 
@@ -280,8 +280,8 @@ fn main() {
     loop {
         if let Err(e) = run(&settings, &mut state, &mut first_run) {
             error!("{}", e);
-            // If we're in fail-fast mode, exit immediately.
-            if settings.fail_fast {
+            // If we're in fail-on-docker-exit mode, exit immediately.
+            if settings.fail_on_docker_exit {
                 error!("Exiting due to --fail-on-docker-exit");
                 exit(1);
             // Otherwise, retry after a short delay.


### PR DESCRIPTION
This PR adds a flag to prevent restarting the `docker event` subprocess.

I'm working on Docker in Docker within Kubernetes, leveraging `docuum` for Docker image management. While docuum effectively cleans up unused images, I encountered an issue with stopping `docuum` containers in a Kubernetes environment. Currently, when attempting to shut down `docuum`, it doesn't respond to the `SIGTERM` signal, necessitating a wait for the Grace Termination Duration before receiving a `SIGKILL`.

I've explored implementing `SIGTERM` handling for `docuum`, but found it to be complex and inelegant. Instead, I propose introducing an `--fail-fast` option. With this option, if the Docker engine goes down, `docuum` will shut down as well. This enhancement is particularly valuable in Kubernetes setups, where Kubernetes will restart the `docuum` container if the Docker engine isn't ready. Additionally, this ensures `docuum` can correctly terminate when shutting down the entire pod.

**Status:** Ready

**Fixes (Partly):** https://github.com/stepchowfun/docuum/issues/234
