### PR TITLE
Remove an unnecessary call to `number_of_values`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,6 @@ fn settings() -> io::Result<Settings> {
                 .value_name("DELETION CHUNK SIZE")
                 .short("d")
                 .long(DELETION_CHUNK_SIZE_OPTION)
-                .number_of_values(1)
                 .help(&format!(
                     "Removes specified quantity of images at a time \
                         (default: {DEFAULT_DELETION_CHUNK_SIZE})",


### PR DESCRIPTION
Remove an unnecessary call to `number_of_values`.

**Status:** Ready

**Fixes:** N/A