### PR TITLE
Adding min-age command line option (-m, --min-age)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.25.0] - 2024-05-02
 
-### Fixed
+### Added
 - Added `--min-age` argument.
 
 ## [0.24.0] - 2024-04-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2024-05-02
+
+### Fixed
+- Added `--min-age` argument.
+
 ## [0.24.0] - 2024-04-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "atty",
  "byte-unit",
@@ -229,6 +229,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "log",
+ "parse_duration",
  "regex",
  "serde",
  "serde_json",
@@ -438,6 +439,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +529,17 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "parse_duration"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
+dependencies = [
+ "lazy_static",
+ "num",
+ "regex",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2021"
 description = "LRU eviction of Docker images."
@@ -28,6 +28,7 @@ regex = { version = "1.5.5", default-features = false, features = ["std", "unico
 serde_json = "1.0"
 serde_yaml = "0.8"
 tempfile = "3"
+parse_duration = "2.1.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sysinfo = "0.23.5"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ OPTIONS:
     -t, --threshold <THRESHOLD>
             Sets the maximum amount of space to be used for Docker images (default: 10 GB)
 
+    -o, --older-than <OLDER THAN>
+            Sets the minimum age of images to be considered for deletion
+
     -v, --version
             Prints version information
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ OPTIONS:
     -t, --threshold <THRESHOLD>
             Sets the maximum amount of space to be used for Docker images (default: 10 GB)
 
-    -m, --min-age <DURATION>
+    -m, --min-age <MIN AGE>
             Sets the minimum age of images to be considered for deletion
 
     -v, --version

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ OPTIONS:
     -k, --keep <REGEX>...
             Prevents deletion of images for which repository:tag matches <REGEX>
 
-    -t, --threshold <THRESHOLD>
-            Sets the maximum amount of space to be used for Docker images (default: 10 GB)
-
     -m, --min-age <MIN AGE>
             Sets the minimum age of images to be considered for deletion
+
+    -t, --threshold <THRESHOLD>
+            Sets the maximum amount of space to be used for Docker images (default: 10 GB)
 
     -v, --version
             Prints version information

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ OPTIONS:
     -t, --threshold <THRESHOLD>
             Sets the maximum amount of space to be used for Docker images (default: 10 GB)
 
-    -o, --older-than <OLDER THAN>
+    -m, --min-age <Duration>
             Sets the minimum age of images to be considered for deletion
 
     -v, --version

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ OPTIONS:
     -t, --threshold <THRESHOLD>
             Sets the maximum amount of space to be used for Docker images (default: 10 GB)
 
-    -m, --min-age <Duration>
+    -m, --min-age <DURATION>
             Sets the minimum age of images to be considered for deletion
 
     -v, --version

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,10 +202,10 @@ fn settings() -> io::Result<Settings> {
         )
         .arg(
             Arg::with_name(MIN_AGE_OPTION)
-                .value_name("MIN AGE")
+                .value_name("DURATION")
                 .short("m")
                 .long(MIN_AGE_OPTION)
-                .help("Specifies which images to delete based image creation time"),
+                .help("Sets the minimum age of images to be considered for deletion"),
         )
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use {
         str::FromStr, 
         sync::{Arc, Mutex}, 
         thread::sleep, 
-        time::Duration
+        time::Duration,
     }
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,7 @@ fn settings() -> io::Result<Settings> {
         )
         .arg(
             Arg::with_name(MIN_AGE_OPTION)
-                .value_name("DURATION")
+                .value_name("MIN AGE")
                 .short("m")
                 .long(MIN_AGE_OPTION)
                 .help("Sets the minimum age of images to be considered for deletion"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,8 @@ use {
     parse_duration::parse, 
     regex::RegexSet, 
     std::{
-        env, io::{self, Write}, 
+        env, 
+        io::{self, Write}, 
         process::exit, 
         str::FromStr, 
         sync::{Arc, Mutex}, 
@@ -236,11 +237,9 @@ fn settings() -> io::Result<Settings> {
 
     // Determine the minimum age for images to be considered for deletion.
     let min_age = match matches.value_of(MIN_AGE_OPTION) {
-        Some(value) => {
-            match parse(value) {
-                Ok(duration) => Some(duration),
-                Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
-            }
+        Some(value) => match parse(value) {
+            Ok(duration) => Some(duration),
+            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
         },
         None => None,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use {
     clap::{App, AppSettings, Arg},
     env_logger::{fmt::Color, Builder},
     log::{Level, LevelFilter},
-    regex::RegexSet,
+    regex::{Regex, RegexSet},
     std::{
         env,
         io::{self, Write},
@@ -269,6 +269,7 @@ fn settings() -> io::Result<Settings> {
         threshold,
         keep,
         deletion_chunk_size,
+        older_than,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,22 +3,22 @@ mod run;
 mod state;
 
 use {
-    crate::{format::CodeStr, run::run}, 
-    atty::Stream, 
-    byte_unit::Byte, 
-    chrono::Local, 
-    clap::{App, AppSettings, Arg}, 
-    env_logger::{fmt::Color, Builder}, 
-    log::{Level, LevelFilter}, 
-    parse_duration::parse, 
-    regex::RegexSet, 
+    crate::{format::CodeStr, run::run},
+    atty::Stream,
+    byte_unit::Byte,
+    chrono::Local,
+    clap::{App, AppSettings, Arg},
+    env_logger::{fmt::Color, Builder},
+    log::{Level, LevelFilter},
+    parse_duration::parse,
+    regex::RegexSet,
     std::{
-        env, 
-        io::{self, Write}, 
-        process::exit, 
-        str::FromStr, 
-        sync::{Arc, Mutex}, 
-        thread::sleep, 
+        env,
+        io::{self, Write},
+        process::exit,
+        str::FromStr,
+        sync::{Arc, Mutex},
+        thread::sleep,
         time::Duration,
     }
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,22 @@ mod run;
 mod state;
 
 use {
-    crate::{format::CodeStr, run::run}, atty::Stream, byte_unit::Byte, chrono::Local, clap::{App, AppSettings, Arg}, env_logger::{fmt::Color, Builder}, log::{Level, LevelFilter}, parse_duration::parse, regex::RegexSet, std::{
-        env, io::{self, Write}, process::exit, str::FromStr, sync::{Arc, Mutex}, thread::sleep, time::Duration
+    crate::{format::CodeStr, run::run}, 
+    atty::Stream, 
+    byte_unit::Byte, 
+    chrono::Local, 
+    clap::{App, AppSettings, Arg}, 
+    env_logger::{fmt::Color, Builder}, 
+    log::{Level, LevelFilter}, 
+    parse_duration::parse, 
+    regex::RegexSet, 
+    std::{
+        env, io::{self, Write}, 
+        process::exit, 
+        str::FromStr, 
+        sync::{Arc, Mutex}, 
+        thread::sleep, 
+        time::Duration
     }
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use {
         sync::{Arc, Mutex},
         thread::sleep,
         time::Duration,
-    }
+    },
 };
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,8 +202,8 @@ fn settings() -> io::Result<Settings> {
         )
         .arg(
             Arg::with_name(MIN_AGE_OPTION)
-                .value_name("OLDER THAN")
-                .short("o")
+                .value_name("MIN AGE")
+                .short("m")
                 .long(MIN_AGE_OPTION)
                 .help("Specifies which images to delete based image creation time"),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,24 +3,9 @@ mod run;
 mod state;
 
 use {
-    crate::{format::CodeStr, run::run},
-    atty::Stream,
-    byte_unit::Byte,
-    chrono::Local,
-    clap::{App, AppSettings, Arg},
-    env_logger::{fmt::Color, Builder},
-    log::{Level, LevelFilter},
-    regex::{Regex, RegexSet},
-    parse_duration::parse,
-    std::{
-        env,
-        io::{self, Write},
-        process::exit,
-        str::FromStr,
-        sync::{Arc, Mutex},
-        thread::sleep,
-        time::Duration,
-    },
+    crate::{format::CodeStr, run::run}, atty::Stream, byte_unit::Byte, chrono::Local, clap::{App, AppSettings, Arg}, env_logger::{fmt::Color, Builder}, log::{Level, LevelFilter}, parse_duration::parse, regex::RegexSet, std::{
+        env, io::{self, Write}, process::exit, str::FromStr, sync::{Arc, Mutex}, thread::sleep, time::Duration
+    }
 };
 
 #[macro_use]
@@ -235,17 +220,12 @@ fn settings() -> io::Result<Settings> {
         None => DEFAULT_DELETION_CHUNK_SIZE,
     };
 
-    // validates the input argument parsed into --min-age and converts input to a duration
+    // Determine the minimum age for images to be considered for deletion.
     let min_age = match matches.value_of(MIN_AGE_OPTION) {
         Some(value) => {
-            let regex = Regex::new(r"(\d+)([smhd])").unwrap();
-            if regex.is_match(value) {
-                match parse(value) {
-                    Ok(duration) => Some(duration),
-                    Err(_) => None
-                }
-            } else {
-                None
+            match parse(value) {
+                Ok(duration) => Some(duration),
+                Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
             }
         },
         None => None,

--- a/src/run.rs
+++ b/src/run.rs
@@ -671,7 +671,8 @@ fn vacuum(
         });
     }
 
-    // If the user provided the `--min-age` argument, we need to filter out images which are newer than the provided duration.
+    // If the `--min-age` argument is provided, we need to filter out images
+    // which are newer than the provided duration.
     if let Some(duration) = min_age {
         match (SystemTime::now() - *duration).duration_since(UNIX_EPOCH) {
             Ok(time_stamp) => {

--- a/src/run.rs
+++ b/src/run.rs
@@ -671,7 +671,7 @@ fn vacuum(
         });
     }
 
-    // If the user provided the `--older-than` argument, we need to filter out images which are newer than the provided duration.
+    // If the user provided the `--min-age` argument, we need to filter out images which are newer than the provided duration.
     if let Some(duration) = min_age {
         let now = SystemTime::now();
         match (now - *duration).duration_since(UNIX_EPOCH) {

--- a/src/run.rs
+++ b/src/run.rs
@@ -677,8 +677,8 @@ fn vacuum(
             Ok(time_stamp) => {
                 sorted_image_nodes
                     .retain(|(_, image_node)| image_node.last_used_since_epoch < time_stamp);
-            },
-            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e))
+            }
+            Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
         };
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -676,16 +676,13 @@ fn vacuum(
     if let Some(duration) = min_age {
         match (SystemTime::now() - *duration).duration_since(UNIX_EPOCH) {
             Ok(time_stamp) => {
-                sorted_image_nodes.retain(|(_, image_node)| {
+                sorted_image_nodes.retain(|(image_id, image_node)| {
                     if image_node.last_used_since_epoch > time_stamp {
-                        for repository_tag in &image_node.image_record.repository_tags {
-                            debug!(
-                                "Ignored image {} due to the {} flag.",
-                                format!("{}:{}", repository_tag.repository, repository_tag.tag)
-                                    .code_str(),
-                                "--min-age".code_str(),
-                            );
-                        }
+                        debug!(
+                            "Ignored image {} due to the {} flag.",
+                            image_id,
+                            "--min-age".code_str(),
+                        );
 
                         return false;
                     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -680,7 +680,7 @@ fn vacuum(
                     if image_node.last_used_since_epoch > time_stamp {
                         debug!(
                             "Ignored image {} due to the {} flag.",
-                            image_id,
+                            image_id.code_str(),
                             "--min-age".code_str(),
                         );
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -675,9 +675,8 @@ fn vacuum(
     if let Some(duration) = min_age {
         match (SystemTime::now() - *duration).duration_since(UNIX_EPOCH) {
             Ok(time_stamp) => {
-                sorted_image_nodes.retain(|(_, image_node)| {
-                    image_node.last_used_since_epoch < time_stamp
-                });
+                sorted_image_nodes
+                    .retain(|(_, image_node)| image_node.last_used_since_epoch < time_stamp);
             },
             Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e))
         };

--- a/src/run.rs
+++ b/src/run.rs
@@ -673,8 +673,7 @@ fn vacuum(
 
     // If the user provided the `--min-age` argument, we need to filter out images which are newer than the provided duration.
     if let Some(duration) = min_age {
-        let now = SystemTime::now();
-        match (now - *duration).duration_since(UNIX_EPOCH) {
+        match (SystemTime::now() - *duration).duration_since(UNIX_EPOCH) {
             Ok(time_stamp) => {
                 sorted_image_nodes.retain(|(_, image_node)| {
                     image_node.last_used_since_epoch < time_stamp

--- a/src/run.rs
+++ b/src/run.rs
@@ -676,8 +676,22 @@ fn vacuum(
     if let Some(duration) = min_age {
         match (SystemTime::now() - *duration).duration_since(UNIX_EPOCH) {
             Ok(time_stamp) => {
-                sorted_image_nodes
-                    .retain(|(_, image_node)| image_node.last_used_since_epoch < time_stamp);
+                sorted_image_nodes.retain(|(_, image_node)| {
+                    if image_node.last_used_since_epoch > time_stamp {
+                        for repository_tag in &image_node.image_record.repository_tags {
+                            debug!(
+                                "Ignored image {} due to the {} flag.",
+                                format!("{}:{}", repository_tag.repository, repository_tag.tag)
+                                    .code_str(),
+                                "--min-age".code_str(),
+                            );
+                        }
+
+                        return false;
+                    }
+
+                    true
+                });
             }
             Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
         };


### PR DESCRIPTION
The change implements the older-than flag, which takes arguments in the following format '{duration}{unit}' where unit is either s (seconds), m (minutes), h (hours), d (days). 

The flag is used to keep images newer than the designated time, by comparing Image.last_used_since_epoch and now - older-than.

**Status:** Ready

**Fixes:** [https://github.com/stepchowfun/docuum/issues/302](url)
