### PR TITLE
feat: update alpine to v3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The base image for the build stage
-FROM --platform=$BUILDPLATFORM alpine:3.15 AS build
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS build
 
 # Choose the appropriate Docuum binary to install.
 ARG TARGETPLATFORM
@@ -8,7 +8,7 @@ COPY artifacts/docuum-aarch64-unknown-linux-musl /tmp/linux/arm64
 RUN cp "/tmp/$TARGETPLATFORM" /usr/local/bin/docuum
 
 # A minimal base image
-FROM --platform=$TARGETPLATFORM alpine:3.15
+FROM --platform=$TARGETPLATFORM alpine:3.20
 
 # Install the Docker CLI.
 RUN apk add --no-cache docker-cli


### PR DESCRIPTION
Alpine 3.15 is EOL since 2023-11-01[^1]

**Status:** Ready

**Fixes:** -

[^1]: https://alpinelinux.org/releases/