### PR TITLE
install.sh: Attempt to restore SELinux attributes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,14 @@
   # Remove the temporary directory.
   rm -rf "$TEMPDIR"
 
+  # If SElinux is installed, try to restore attributes
+  # shellcheck disable=SC2024
+  if command -v restorecon > /dev/null; then
+    restorecon "$DESTINATION" 2> /dev/null ||
+     sudo restorecon "$DESTINATION" < /dev/tty ||
+       echo 'Failed to restore SELinux attributes, this may or may not be a problem.'
+  fi
+
   # Let the user know if the installation was successful.
   "$DESTINATION" --version || fail 'There was an error installing the binary.'
 )


### PR DESCRIPTION
Took me a while to figure out... Might be helpful to others.

In particular, this is required on Rocky Linux 9.5 for docuum to run as a systemd service.

**Status:** Ready

**Fixes:** N/A
