### PR TITLE
Switch from unmaintained parse_duration to humantime.parse_duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,8 +211,8 @@ dependencies = [
  "ctrlc",
  "dirs",
  "env_logger",
+ "humantime",
  "log",
- "parse_duration",
  "regex",
  "serde",
  "serde_json",
@@ -279,6 +279,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "iana-time-zone"
@@ -396,73 +402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,17 +415,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "parse_duration"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
-dependencies = [
- "lazy_static",
- "num",
- "regex",
-]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ regex = { version = "1.5.5", default-features = false, features = ["std", "unico
 serde_json = "1.0"
 serde_yaml = "0.8"
 tempfile = "3"
-parse_duration = "2.1.1"
+humantime = "2.2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sysinfo = "0.23.5"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ OPTIONS:
 
 The `--threshold` flag accepts [multiple representations](https://docs.rs/byte-unit/4.0.12/byte_unit/struct.Byte.html#examples-2), like `10 GB`, `10 GiB`, or `10GB`. On Linux, percentage-based thresholds like `50%` are also supported.
 
-The `--min-age` flag accepts [multiple representations](https://docs.rs/parse_duration/2.1.1/parse_duration/), such as `4 days` or `1 hour`.
+The `--min-age` flag accepts [multiple representations](https://docs.rs/humantime/latest/humantime/fn.parse_duration.html), such as `4d` or `1 hour`.
 
 You can change the log verbosity by setting an environment variable named `LOG_LEVEL` to one of `trace`, `debug`, `info`, `warning`, or `error`. The default is `debug`.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use {
     chrono::Local,
     clap::{App, AppSettings, Arg},
     env_logger::{Builder, fmt::Color},
+    humantime::parse_duration,
     log::{Level, LevelFilter},
-    parse_duration::parse,
     regex::RegexSet,
     std::{
         env,
@@ -229,8 +229,15 @@ fn settings() -> io::Result<Settings> {
 
     // Determine the minimum age for images to be considered for deletion.
     let min_age = match matches.value_of(MIN_AGE_OPTION) {
-        Some(value) => match parse(value) {
-            Ok(duration) => Some(duration),
+        Some(value) => match parse_duration(value) {
+            Ok(duration) => {
+                debug!(
+                    "{} parsed as {:?}.",
+                    format!("--{MIN_AGE_OPTION}").code_str(),
+                    duration,
+                );
+                Some(duration)
+            }
             Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
         },
         None => None,


### PR DESCRIPTION
This does seem a bit more strict but the two examples that we're already there still worked. Humantime seems to like it more like 4days instead of 4 days - but both work.

Also added a debug line to print it out to make sure it was doing the same as before.

Fixes: #335

A clear description of the change.

**Status:** Needs more testing?