### PR TITLE
Zombie Container (stuck in status=removing) causes Doccum to repeatedly crash

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -222,12 +222,18 @@ fn image_ids_in_use() -> io::Result<HashSet<String>> {
             "container",
             "ls",
             "--all",
-            "--filter", "status=created",
-            "--filter", "status=restarting",
-            "--filter", "status=running",
-            "--filter", "status=paused",
-            "--filter", "status=exited",
-            "--filter", "status=dead",
+            "--filter",
+            "status=created",
+            "--filter",
+            "status=restarting",
+            "--filter",
+            "status=running",
+            "--filter",
+            "status=paused",
+            "--filter",
+            "status=exited",
+            "--filter",
+            "status=dead",
             "--no-trunc",
             "--format",
             "{{.ID}}",
@@ -237,9 +243,7 @@ fn image_ids_in_use() -> io::Result<HashSet<String>> {
 
     // Ensure the command succeeded.
     if !container_ids_output.status.success() {
-        return Err(io::Error::other(
-            "Unable to list containers.",
-        ));
+        return Err(io::Error::other("Unable to list containers."));
     }
 
     // Interpret the output bytes as UTF-8 and parse the lines.

--- a/src/run.rs
+++ b/src/run.rs
@@ -222,6 +222,12 @@ fn image_ids_in_use() -> io::Result<HashSet<String>> {
             "container",
             "ls",
             "--all",
+            "--filter", "status=created",
+            "--filter", "status=restarting",
+            "--filter", "status=running",
+            "--filter", "status=paused",
+            "--filter", "status=exited",
+            "--filter", "status=dead",
             "--no-trunc",
             "--format",
             "{{.ID}}",
@@ -232,7 +238,7 @@ fn image_ids_in_use() -> io::Result<HashSet<String>> {
     // Ensure the command succeeded.
     if !container_ids_output.status.success() {
         return Err(io::Error::other(
-            "Unable to determine IDs of images currently in use by containers.",
+            "Unable to list containers.",
         ));
     }
 


### PR DESCRIPTION
**Issue**
When [there is Container stuck on host](https://stackoverflow.com/questions/66753276/unused-docker-containers-stuck-in-removal-in-progress-state-device-or-resource) with Status "Removal In Progress". 
Any docker operation on such container e.g `docker inspect` returns with No such Container error.

In case of Docuum, having such container on host causes `docker inspect` to crash causing a infinite loop of Docuum restarting & throwing the error. 

 **Solution**
The PR adds a filter to container list, now containers in removing state won't be listed & hence docker inspect on such container would not throw and error. 

**Side effects**
No. The Filtering is not a new docker feature & any operations on the container that is in removing state returns in error. Either container from that state will be gone in the next docuum run (after crash -> where removing succeeds) or docuum would stuck in a loop of crashing & restarting.

Docker Containers Statuses: 
https://docs.docker.com/reference/cli/docker/container/ls/#status


**Logs**
```
dca18-4f:/# docker ps -a | grep Removal
c30817041a40   91abaee84fc1             "/usr/bin/tini -v --…"   3 days ago    Removal In Progress     

dca18-4f:/# docker inspect c30817041a40
[]
Error: No such object: c30817041a40

```


**What is the Status of Such Conatiner**
```
dca18-4f:/# docker container ls --filter "status=removing"
CONTAINER ID   IMAGE          COMMAND                  CREATED      STATUS                PORTS     NAMES
c30817041a40   91abaee84fc1   "/usr/bin/tini -v --…"   3 days ago   Removal In Progress  
```