### PR TITLE
Add support for ARMv7 GNU Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,17 @@ jobs:
         name: aarch64-unknown-linux-musl
         path: artifacts/docuum
         if-no-files-found: error
+    - run: |
+        # Make Bash log commands and not silently ignore errors.
+        set -euxo pipefail
+
+        # The artifact name will contain the target triple, so the file name doesn't need to.
+        mv artifacts/docuum-armv7-unknown-linux-gnueabihf artifacts/docuum
+    - uses: actions/upload-artifact@v4
+      with:
+        name: armv7-unknown-linux-gnueabihf
+        path: artifacts/docuum
+        if-no-files-found: error
   ci-windows:
     name: Build for Windows
     runs-on: windows-latest
@@ -240,6 +251,9 @@ jobs:
           artifacts/aarch64-unknown-linux-musl/docuum \
           artifacts/docuum-aarch64-unknown-linux-musl
         mv \
+          artifacts/armv7-unknown-linux-gnueabihf/docuum \
+          artifacts/docuum-armv7-unknown-linux-gnueabihf
+        mv \
           artifacts/x86_64-apple-darwin/docuum \
           artifacts/docuum-x86_64-apple-darwin
         mv \
@@ -256,12 +270,13 @@ jobs:
         # https://github.com/actions/upload-artifact/issues/38.
         chmod a+x artifacts/docuum-x86_64-unknown-linux-musl
         chmod a+x artifacts/docuum-aarch64-unknown-linux-musl
+        chmod a+x artifacts/docuum-armv7-unknown-linux-gnueabihf
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
       uses: docker/build-push-action@v5
       with:
         context: .
         push: true
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
         tags: stephanmisc/docuum,stephanmisc/docuum:${{ env.VERSION_TO_PUBLISH }}
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
       env:
@@ -288,6 +303,7 @@ jobs:
           'artifacts/docuum-x86_64-unknown-linux-musl' \
           'artifacts/docuum-aarch64-unknown-linux-gnu' \
           'artifacts/docuum-aarch64-unknown-linux-musl' \
+          'artifacts/docuum-armv7-unknown-linux-gnueabihf' \
           'artifacts/docuum-x86_64-apple-darwin' \
           'artifacts/docuum-aarch64-apple-darwin' \
           'artifacts/docuum-x86_64-pc-windows-msvc.exe' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM --platform=$BUILDPLATFORM alpine:3.20 AS build
 ARG TARGETPLATFORM
 COPY artifacts/docuum-x86_64-unknown-linux-musl /tmp/linux/amd64
 COPY artifacts/docuum-aarch64-unknown-linux-musl /tmp/linux/arm64
+COPY artifacts/armv7-unknown-linux-gnueabihf /tmp/linux/arm/v7
 RUN cp "/tmp/$TARGETPLATFORM" /usr/local/bin/docuum
 
 # A minimal base image

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,9 @@
   elif uname -a | grep -qi 'aarch64.*Linux'; then
     echo 'AArch64 non-GNU Linux detected.'
     FILENAME=docuum-aarch64-unknown-linux-musl
+  elif uname -a | grep -qi 'armv7l.*GNU/Linux'; then
+    echo 'ARMv7 GNU Linux detected.'
+    FILENAME=docuum-armv7-unknown-linux-gnueabihf
   elif uname -a | grep -qi 'Darwin.*x86_64'; then
     echo 'x86-64 macOS detected.'
     FILENAME=docuum-x86_64-apple-darwin

--- a/toast.yml
+++ b/toast.yml
@@ -32,15 +32,16 @@ tasks:
     command: |
       # Install the following packages:
       #
-      # - build-essential       - Used to link some crates
-      # - ca-certificates       - Used for fetching Docker's GPG key
-      # - curl                  - Used for installing Docker, Tagref, and Rust
-      # - gcc-aarch64-linux-gnu - Used for linking the binary for AArch64
-      # - gcc-x86-64-linux-gnu  - Used for linking the binary for x86-64
-      # - gnupg                 - Used to install Docker's GPG key
-      # - lsb-release           - Used below to determine the Ubuntu release codename
-      # - ripgrep               - Used for various linting tasks
-      # - shellcheck            - Used for linting shell scripts
+      # - build-essential         - Used to link some crates
+      # - ca-certificates         - Used for fetching Docker's GPG key
+      # - curl                    - Used for installing Docker, Tagref, and Rust
+      # - gcc-aarch64-linux-gnu   - Used for linking the binary for AArch64
+      # - gcc-x86-64-linux-gnu    - Used for linking the binary for x86-64
+      # - gcc-arm-linux-gnueabihf - Used for linking the binary for ARMv7
+      # - gnupg                   - Used to install Docker's GPG key
+      # - lsb-release             - Used below to determine the Ubuntu release codename
+      # - ripgrep                 - Used for various linting tasks
+      # - shellcheck              - Used for linting shell scripts
       apt-get update
       apt-get install --yes \
         build-essential \
@@ -48,6 +49,7 @@ tasks:
         curl \
         gcc-aarch64-linux-gnu \
         gcc-x86-64-linux-gnu \
+        gcc-arm-linux-gnueabihf \
         gnupg \
         lsb-release \
         ripgrep \
@@ -240,18 +242,21 @@ tasks:
       rustup target add x86_64-unknown-linux-musl
       rustup target add aarch64-unknown-linux-gnu
       rustup target add aarch64-unknown-linux-musl
+      rustup target add armv7-unknown-linux-gnueabihf
 
       # Set the linkers.
       export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
       export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-gnu-gcc
       export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
       export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
+      export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
 
       # Build the project with Cargo for each Linux target.
       cargo-online build --release --target x86_64-unknown-linux-gnu
       cargo-online build --release --target x86_64-unknown-linux-musl
       cargo-online build --release --target aarch64-unknown-linux-gnu
       cargo-online build --release --target aarch64-unknown-linux-musl
+      cargo-online build --release --target armv7-unknown-linux-gnueabihf
 
       # Move the binaries to a more conveniennt location for exporting.
       mkdir artifacts
@@ -267,6 +272,9 @@ tasks:
       cp \
         target/aarch64-unknown-linux-musl/release/docuum \
         artifacts/docuum-aarch64-unknown-linux-musl
+      cp \
+        target/armv7-unknown-linux-gnueabihf/release/docuum \
+        artifacts/armv7-unknown-linux-gnueabihf
 
   validate_release:
     description: Validate the release.

--- a/toast.yml
+++ b/toast.yml
@@ -36,8 +36,8 @@ tasks:
       # - ca-certificates         - Used for fetching Docker's GPG key
       # - curl                    - Used for installing Docker, Tagref, and Rust
       # - gcc-aarch64-linux-gnu   - Used for linking the binary for AArch64
-      # - gcc-x86-64-linux-gnu    - Used for linking the binary for x86-64
       # - gcc-arm-linux-gnueabihf - Used for linking the binary for ARMv7
+      # - gcc-x86-64-linux-gnu    - Used for linking the binary for x86-64
       # - gnupg                   - Used to install Docker's GPG key
       # - lsb-release             - Used below to determine the Ubuntu release codename
       # - ripgrep                 - Used for various linting tasks
@@ -48,8 +48,8 @@ tasks:
         ca-certificates \
         curl \
         gcc-aarch64-linux-gnu \
-        gcc-x86-64-linux-gnu \
         gcc-arm-linux-gnueabihf \
+        gcc-x86-64-linux-gnu \
         gnupg \
         lsb-release \
         ripgrep \

--- a/toast.yml
+++ b/toast.yml
@@ -274,7 +274,7 @@ tasks:
         artifacts/docuum-aarch64-unknown-linux-musl
       cp \
         target/armv7-unknown-linux-gnueabihf/release/docuum \
-        artifacts/armv7-unknown-linux-gnueabihf
+        artifacts/docuum-armv7-unknown-linux-gnueabihf
 
   validate_release:
     description: Validate the release.


### PR DESCRIPTION
Adds support for ARMv7 (32-bit) processors like in the Raspberry Pi 2 Model B v1.1

**Status:** WIP
