### PR TITLE
Skip images in use by containers during vacuum

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -638,6 +638,7 @@ fn construct_polyforest(
 }
 
 // The main vacuum logic
+#[allow(clippy::too_many_lines)]
 fn vacuum(
     state: &mut State,
     first_run: bool,

--- a/src/run.rs
+++ b/src/run.rs
@@ -664,6 +664,20 @@ fn vacuum(
             .then(y.1.ancestors.cmp(&x.1.ancestors))
     });
 
+    // Filter out images currently in use by containers. Attempting to delete these with `--force`
+    // would only untag them without freeing any space.
+    sorted_image_nodes.retain(|(image_id, _)| {
+        if image_ids_in_use.contains(*image_id) {
+            debug!(
+                "Skipping image {} because it is in use by a container.",
+                image_id.code_str(),
+            );
+            return false;
+        }
+
+        true
+    });
+
     // If the user provided the `--keep` argument, we need to filter out images which match the
     // provided regexes.
     if let Some(regex_set) = keep {


### PR DESCRIPTION
## Summary

- Exclude images currently in use by containers from deletion candidates during vacuum
- Previously, in-use images only had their LRU timestamps bumped but were still eligible for deletion under disk pressure
- `docker image rm --force --no-prune` on an in-use image untags it without freeing space, leaving `<none>:<none>` entries in `docker image ls`
- This is particularly problematic for Docker Swarm services that reference images by tag

## Details

The `image_ids_in_use()` function already queries Docker for container image IDs. The vacuum logic used this set to bump timestamps (making in-use images "most recently used"), but under enough disk pressure, it would eventually reach them in the sorted deletion list.

The fix adds a `retain` filter that excludes in-use images entirely, consistent with how `--keep` and `--min-age` already work.