### PR TITLE
Move publish release Docker setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,6 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v4
-    - uses: docker/setup-qemu-action@v3 # For building multi-platform images
-    - uses: docker/setup-buildx-action@v3 # For building multi-platform images
     - uses: docker/login-action@v3
       with:
         username: stephanmisc
@@ -256,6 +254,8 @@ jobs:
         # https://github.com/actions/upload-artifact/issues/38.
         chmod a+x artifacts/docuum-x86_64-unknown-linux-musl
         chmod a+x artifacts/docuum-aarch64-unknown-linux-musl
+    - uses: docker/setup-qemu-action@v3 # For building multi-platform images
+    - uses: docker/setup-buildx-action@v3 # For building multi-platform images
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
       uses: docker/build-push-action@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,8 +254,10 @@ jobs:
         # https://github.com/actions/upload-artifact/issues/38.
         chmod a+x artifacts/docuum-x86_64-unknown-linux-musl
         chmod a+x artifacts/docuum-aarch64-unknown-linux-musl
-    - uses: docker/setup-qemu-action@v3 # For building multi-platform images
-    - uses: docker/setup-buildx-action@v3 # For building multi-platform images
+    - if: ${{ env.VERSION_TO_PUBLISH != null }}
+      uses: docker/setup-buildx-action@v3 # For building multi-platform images
+    - if: ${{ env.VERSION_TO_PUBLISH != null }}
+      uses: docker/setup-qemu-action@v3 # For building multi-platform images
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
       uses: docker/build-push-action@v5
       with:


### PR DESCRIPTION
Moves the QEMU and Buildx setup steps in publish-release to immediately before the Docker build-push action.

**Status:** Ready

**Fixes:** N/A