### PR TITLE
Bump Rust to 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
         #   https://github.com/rust-lang/rustup/issues/2441
         #
         # for more information.
-        rustup toolchain install 1.95.0 --no-self-update # [ref:rust_1.95.0]
-        rustup default 1.95.0 # [ref:rust_1.95.0]
+        rustup toolchain install 1.96.0 --no-self-update # [ref:rust_1.96.0]
+        rustup default 1.96.0 # [ref:rust_1.96.0]
 
         # Add the targets.
         rustup target add x86_64-pc-windows-msvc
@@ -131,8 +131,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.95.0 # [ref:rust_1.95.0]
-        rustup default 1.95.0 # [ref:rust_1.95.0]
+        rustup toolchain install 1.96.0 # [ref:rust_1.96.0]
+        rustup default 1.96.0 # [ref:rust_1.96.0]
 
         # Add the targets.
         rustup target add x86_64-apple-darwin
@@ -211,8 +211,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.95.0 # [ref:rust_1.95.0]
-        rustup default 1.95.0 # [ref:rust_1.95.0]
+        rustup toolchain install 1.96.0 # [ref:rust_1.96.0]
+        rustup default 1.96.0 # [ref:rust_1.96.0]
 
         # Fetch the program version.
         VERSION="$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"

--- a/toast.yml
+++ b/toast.yml
@@ -17,11 +17,11 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-04-25]. The
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-06-09]. The
   # nightly version was chosen as the latest available release with all components present
   # according to this page:
   #   https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  cargo-fmt () { cargo +nightly-2026-04-25 --frozen --offline fmt --all -- "$@"; }
+  cargo-fmt () { cargo +nightly-2026-06-09 --frozen --offline fmt --all -- "$@"; }
 
   # Make Bash log commands.
   set -x
@@ -92,18 +92,18 @@ tasks:
       - install_packages
       - create_user
     command: |
-      # Install stable Rust [tag:rust_1.95.0].
+      # Install stable Rust [tag:rust_1.96.0].
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         -y \
-        --default-toolchain 1.95.0 \
+        --default-toolchain 1.96.0 \
         --profile minimal \
         --component clippy
 
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2026-04-25].
-      rustup toolchain install nightly-2026-04-25 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly_2026-06-09].
+      rustup toolchain install nightly-2026-06-09 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.


### PR DESCRIPTION
## Summary
- bump the stable Rust toolchain from 1.95.0 to 1.96.0
- bump the pinned nightly rustfmt toolchain from nightly-2026-04-25 to nightly-2026-06-09
- update the GitHub Actions workflow pins and tagref links to match

## Testing
- tagref