### PR TITLE
Migrate to yaml_serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,9 +353,9 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yaml",
  "sysinfo",
  "tempfile",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -595,6 +595,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1027,19 +1033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,12 +1191,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8-width"
@@ -1587,6 +1574,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4"
 regex = { version = "1", default-features = false, features = ["std", "unicode-perl"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+yaml_serde = "0.10"
 tempfile = "3"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/state.rs
+++ b/src/state.rs
@@ -64,7 +64,7 @@ pub fn load() -> io::Result<State> {
         let yaml = read_to_string(path)?;
 
         // Deserialize the YAML.
-        serde_yaml::from_str(&yaml).map_err(io::Error::other)
+        yaml_serde::from_str(&yaml).map_err(io::Error::other)
     } else {
         // Fail if we don't have a path.
         Err(io::Error::other("Unable to locate data directory."))
@@ -85,7 +85,7 @@ pub fn save(state: &State) -> io::Result<()> {
         let parent = path.parent().unwrap().to_owned();
 
         // The `unwrap` is safe because serialization should never fail.
-        let payload = serde_yaml::to_string(state).unwrap();
+        let payload = yaml_serde::to_string(state).unwrap();
 
         // Create the ancestor directories, if needed.
         create_dir_all(parent.clone())?;


### PR DESCRIPTION
Migrate from the deprecated, unmaintained `serde_yaml` crate to the maintained `yaml_serde` fork. Update the YAML call sites and lockfile accordingly.

**Status:** Ready

**Fixes:** N/A