### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     name: Build for Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v4.1.0
+      uses: docker/login-action@v4.2.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -79,7 +79,7 @@ jobs:
         # The unit tests do not expect the files in `test_data` to have carriage returns added.
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -125,7 +125,7 @@ jobs:
     name: Build for macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -164,7 +164,7 @@ jobs:
     name: Install on macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -178,7 +178,7 @@ jobs:
     name: Install on Ubuntu
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - run: |
         # Make Bash log commands and not silently ignore errors.
         set -euxo pipefail
@@ -196,8 +196,8 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v6.0.2
-    - uses: docker/login-action@v4.1.0
+    - uses: actions/checkout@v7.0.0
+    - uses: docker/login-action@v4.2.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -255,11 +255,11 @@ jobs:
         chmod a+x artifacts/docuum-x86_64-unknown-linux-musl
         chmod a+x artifacts/docuum-aarch64-unknown-linux-musl
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
-      uses: docker/setup-buildx-action@v3 # For building multi-platform images
+      uses: docker/setup-buildx-action@v4.1.0 # For building multi-platform images
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
-      uses: docker/setup-qemu-action@v3 # For building multi-platform images
+      uses: docker/setup-qemu-action@v4.1.0 # For building multi-platform images
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7.2.0
       with:
         context: .
         push: true
@@ -273,7 +273,7 @@ jobs:
         set -euxo pipefail
 
         # Run the Docker image to validate it. The image has already been published (since the
-        # `docker/build-push-action@v5` action unfortunately doesn't support importing multi-
+        # `docker/build-push-action@v7.2.0` action unfortunately doesn't support importing multi-
         # platform images into a local Docker installation), but we still validate it now anyway.
         docker run \
           --init \


### PR DESCRIPTION
Update pinned GitHub Actions versions to latest:

- `actions/checkout`: v6.0.2 → v7.0.0
- `docker/login-action`: v4.1.0 → v4.2.0
- `docker/setup-buildx-action`: v3 → v4.1.0
- `docker/setup-qemu-action`: v3 → v4.1.0
- `docker/build-push-action`: v5 → v7.2.0

**Status:** Ready

**Fixes:** N/A