### PR TITLE
Update dependencies and Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
         #   https://github.com/rust-lang/rustup/issues/2441
         #
         # for more information.
-        rustup toolchain install 1.96.1 --no-self-update # [ref:rust_1.96.1]
-        rustup default 1.96.1 # [ref:rust_1.96.1]
+        rustup toolchain install 1.97.0 --no-self-update # [ref:rust_1.97.0]
+        rustup default 1.97.0 # [ref:rust_1.97.0]
 
         # Add the targets.
         rustup target add x86_64-pc-windows-msvc
@@ -131,8 +131,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.96.1 # [ref:rust_1.96.1]
-        rustup default 1.96.1 # [ref:rust_1.96.1]
+        rustup toolchain install 1.97.0 # [ref:rust_1.97.0]
+        rustup default 1.97.0 # [ref:rust_1.97.0]
 
         # Add the targets.
         rustup target add x86_64-apple-darwin
@@ -211,8 +211,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.96.1 # [ref:rust_1.96.1]
-        rustup default 1.96.1 # [ref:rust_1.96.1]
+        rustup toolchain install 1.97.0 # [ref:rust_1.97.0]
+        rustup default 1.97.0 # [ref:rust_1.97.0]
 
         # Fetch the program version.
         VERSION="$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -573,9 +573,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -915,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1119,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.5"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
@@ -1485,18 +1485,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ dirs = "6.0.0"
 env_logger = "0.11.11"
 humantime = "2.4.0"
 log = "0.4.33"
-regex = { version = "1.12.4", default-features = false, features = ["std", "unicode-perl"] }
+regex = { version = "1.13.0", default-features = false, features = ["std", "unicode-perl"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 yaml_serde = "0.10.4"
 tempfile = "3.27.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-sysinfo = "0.39.5"
+sysinfo = "0.39.6"
 
 [dependencies.ctrlc]
 version = "3.5.2"

--- a/src/run.rs
+++ b/src/run.rs
@@ -680,8 +680,7 @@ fn vacuum(
             for repository_tag in &image_node.image_record.repository_tags {
                 if regex_set.is_match(&format!(
                     "{}:{}",
-                    repository_tag.repository,
-                    repository_tag.tag,
+                    repository_tag.repository, repository_tag.tag,
                 )) {
                     debug!(
                         "Ignored image {} due to the {} flag.",

--- a/src/run.rs
+++ b/src/run.rs
@@ -680,7 +680,8 @@ fn vacuum(
             for repository_tag in &image_node.image_record.repository_tags {
                 if regex_set.is_match(&format!(
                     "{}:{}",
-                    repository_tag.repository, repository_tag.tag,
+                    repository_tag.repository,
+                    repository_tag.tag,
                 )) {
                     debug!(
                         "Ignored image {} due to the {} flag.",

--- a/toast.yml
+++ b/toast.yml
@@ -17,11 +17,11 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-07-08]. The
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-07-09]. The
   # nightly version was chosen as the latest available release with all components present
   # according to this page:
   #   https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  cargo-fmt () { cargo +nightly-2026-07-08 --frozen --offline fmt --all -- "$@"; }
+  cargo-fmt () { cargo +nightly-2026-07-09 --frozen --offline fmt --all -- "$@"; }
 
   # Make Bash log commands.
   set -x
@@ -92,18 +92,18 @@ tasks:
       - install_packages
       - create_user
     command: |
-      # Install stable Rust [tag:rust_1.96.1].
+      # Install stable Rust [tag:rust_1.97.0].
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         -y \
-        --default-toolchain 1.96.1 \
+        --default-toolchain 1.97.0 \
         --profile minimal \
         --component clippy
 
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2026-07-08].
-      rustup toolchain install nightly-2026-07-08 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly_2026-07-09].
+      rustup toolchain install nightly-2026-07-09 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.


### PR DESCRIPTION
Updates the Rust toolchain from 1.96.1 to 1.97.0 and nightly rustfmt from 2026-07-08 to 2026-07-09.

Also updates direct dependencies regex 1.12.4 -> 1.13.0 and sysinfo 0.39.5 -> 0.39.6, with lockfile refreshes for bytes, jiff, regex-automata, and zerocopy. Changelog review found no required code migration: regex adds the new regex! macro, sysinfo's patch is NetBSD disk-information work, bytes fixes a Box::new panic path, jiff updates bundled tzdata to 2026c, and zerocopy is a patch bump. The new rustfmt nightly produced one formatting change in src/run.rs.

**Status:** Ready

**Fixes:** N/A

