### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,9 +1246,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1505,6 +1505,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"


### PR DESCRIPTION
Updates transitive Cargo dependencies after confirming direct manifest dependencies, Rust/toolchain pins, GitHub Actions pins, submodules, and copyright years are already current.

- Updates `uuid` from 1.23.4 to 1.23.5; upstream notes mention documentation cleanup and UUID parse/format performance work.
- Updates `zmij` from 1.0.21 to 1.0.22; upstream release is a large internal sync for the float formatter crate, with no direct API usage in this repo.

**Status:** Ready

**Fixes:** N/A