### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v4.4.0
+      uses: docker/login-action@v4.5.1
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -197,7 +197,7 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v7.0.1
-    - uses: docker/login-action@v4.4.0
+    - uses: docker/login-action@v4.5.1
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Update `docker/login-action` from v4.4.0 to v4.5.1. The intervening releases add Docker Hub OIDC support (including `dhi.io`) and refresh the action’s internal dependencies; the existing username/password inputs remain compatible. Package dependencies, toolchains, submodules, and the 2026 copyright notice were checked and are already current.

**Status:** Ready

**Fixes:** N/A