### PR TITLE
Update dependencies, Rust, and GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
         #   https://github.com/rust-lang/rustup/issues/2441
         #
         # for more information.
-        rustup toolchain install 1.97.1 --no-self-update # [ref:rust_1.97.1]
-        rustup default 1.97.1 # [ref:rust_1.97.1]
+        rustup toolchain install 1.98.0 --no-self-update # [ref:rust_1.98.0]
+        rustup default 1.98.0 # [ref:rust_1.98.0]
 
         # Add the targets.
         rustup target add x86_64-pc-windows-msvc
@@ -131,8 +131,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.97.1 # [ref:rust_1.97.1]
-        rustup default 1.97.1 # [ref:rust_1.97.1]
+        rustup toolchain install 1.98.0 # [ref:rust_1.98.0]
+        rustup default 1.98.0 # [ref:rust_1.98.0]
 
         # Add the targets.
         rustup target add x86_64-apple-darwin
@@ -211,8 +211,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.97.1 # [ref:rust_1.97.1]
-        rustup default 1.97.1 # [ref:rust_1.97.1]
+        rustup toolchain install 1.98.0 # [ref:rust_1.98.0]
+        rustup default 1.98.0 # [ref:rust_1.98.0]
 
         # Fetch the program version.
         VERSION="$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"
@@ -255,7 +255,7 @@ jobs:
         chmod a+x artifacts/docuum-x86_64-unknown-linux-musl
         chmod a+x artifacts/docuum-aarch64-unknown-linux-musl
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
-      uses: docker/setup-buildx-action@v4.2.0 # For building multi-platform images
+      uses: docker/setup-buildx-action@v4.3.0 # For building multi-platform images
     - if: ${{ env.VERSION_TO_PUBLISH != null }}
       uses: docker/setup-qemu-action@v4.2.0 # For building multi-platform images
     - if: ${{ env.VERSION_TO_PUBLISH != null }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -894,18 +894,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "yaml_serde"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7a8266fc7ce9d77db272ca5b40b704a1753e2a2e2ab7b1f2da22672941bf93"
+checksum = "33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4.33"
 regex = { version = "1.13.1", default-features = false, features = ["std", "unicode-perl"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
-yaml_serde = "0.10.6"
+yaml_serde = "0.10.7"
 tempfile = "3.27.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/toast.yml
+++ b/toast.yml
@@ -17,11 +17,11 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-07-18]. The
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-08-21]. The
   # nightly version was chosen as the latest available release with all components present
   # according to this page:
   #   https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  cargo-fmt () { cargo +nightly-2026-07-18 --frozen --offline fmt --all -- "$@"; }
+  cargo-fmt () { cargo +nightly-2026-08-21 --frozen --offline fmt --all -- "$@"; }
 
   # Make Bash log commands.
   set -x
@@ -92,18 +92,18 @@ tasks:
       - install_packages
       - create_user
     command: |
-      # Install stable Rust [tag:rust_1.97.1].
+      # Install stable Rust [tag:rust_1.98.0].
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         -y \
-        --default-toolchain 1.97.1 \
+        --default-toolchain 1.98.0 \
         --profile minimal \
         --component clippy
 
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2026-07-18].
-      rustup toolchain install nightly-2026-07-18 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly_2026-08-21].
+      rustup toolchain install nightly-2026-08-21 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.


### PR DESCRIPTION
Updates yaml_serde from 0.10.6 to 0.10.7, Rust from 1.97.1 to 1.98.0, nightly rustfmt from 2026-07-18 to 2026-08-21, docker/setup-buildx-action from v4.2.0 to v4.3.0, and refreshed transitive lockfile dependencies. Release notes did not require source changes.

Copyright is already current at 2026 where LICENSE.md is present. No submodule update applies.

**Status:** Ready

**Fixes:** N/A
