### PR TITLE
Don't inspect containers with the dead status

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -26,15 +26,16 @@ use sysinfo::{Disk, Disks};
 // maximum number of container IDs to query at once.
 const CONTAINER_IDS_CHUNK_SIZE: usize = 100;
 
-// The `docker container inspect` command seems to fail on containers with this status. Source:
+// The `docker container inspect` command seems to fail on containers with these statuses. Source:
 // https://github.com/stepchowfun/docuum/issues/237
 const CONTAINER_STATUS_REMOVING: &str = "removing";
+const CONTAINER_STATUS_DEAD: &str = "dead";
 
 // These are all the possible statuses returned from `docker container ls`. Source:
 //   https://docs.docker.com/reference/cli/docker/container/ls/#status
 const CONTAINER_STATUSES: [&str; 7] = [
     "created",
-    "dead",
+    CONTAINER_STATUS_DEAD,
     "exited",
     "paused",
     "restarting",
@@ -253,7 +254,9 @@ fn image_ids_in_use() -> io::Result<HashSet<String>> {
                 .chain(
                     CONTAINER_STATUSES
                         .iter()
-                        .filter(|&&status| status != CONTAINER_STATUS_REMOVING)
+                        .filter(|&&status| {
+                            status != CONTAINER_STATUS_REMOVING && status != CONTAINER_STATUS_DEAD
+                        })
                         .flat_map(|&status| [String::from("--filter"), format!("status={status}")]),
                 )
                 .chain(

--- a/src/run.rs
+++ b/src/run.rs
@@ -28,19 +28,18 @@ const CONTAINER_IDS_CHUNK_SIZE: usize = 100;
 
 // The `docker container inspect` command seems to fail on containers with these statuses. Source:
 // https://github.com/stepchowfun/docuum/issues/237
-const CONTAINER_STATUS_REMOVING: &str = "removing";
-const CONTAINER_STATUS_DEAD: &str = "dead";
+const UNINSPECTABLE_CONTAINER_STATUSES: [&str; 2] = ["dead", "removing"];
 
 // These are all the possible statuses returned from `docker container ls`. Source:
 //   https://docs.docker.com/reference/cli/docker/container/ls/#status
 const CONTAINER_STATUSES: [&str; 7] = [
     "created",
-    CONTAINER_STATUS_DEAD,
+    "dead",
     "exited",
     "paused",
     "restarting",
     "running",
-    CONTAINER_STATUS_REMOVING,
+    "removing",
 ];
 
 // A Docker event (a line of output from `docker system events --format '{{json .}}'`)
@@ -254,9 +253,7 @@ fn image_ids_in_use() -> io::Result<HashSet<String>> {
                 .chain(
                     CONTAINER_STATUSES
                         .iter()
-                        .filter(|&&status| {
-                            status != CONTAINER_STATUS_REMOVING && status != CONTAINER_STATUS_DEAD
-                        })
+                        .filter(|&&status| !UNINSPECTABLE_CONTAINER_STATUSES.contains(&status))
                         .flat_map(|&status| [String::from("--filter"), format!("status={status}")]),
                 )
                 .chain(


### PR DESCRIPTION
A container stuck in the `dead` status makes `docker container inspect` fail, and since a failed chunk is fatal in `image_ids_in_use`, docuum never gets past its initial vacuum and retries every five seconds forever. This is #237 and #341 with a different status, so `dead` is now excluded from the listing the way `removing` already is.

On the affected host the dead container could not be removed, and dropping it from the listing takes the inspect call from exit 1 to exit 0.
