### PR TITLE
Bump version to 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2026-09-01
+
+### Changed
+- Dependencies, Rust, and GitHub Actions have been updated.
+
+### Fixed
+- Docuum no longer inspects containers with the `dead` status.
+
 ## [0.27.0] - 2026-04-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "docuum"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "byte-unit",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docuum"
-version = "0.27.0"
+version = "0.27.1"
 authors = ["Stephan Boyer <stephan@stephanboyer.com>"]
 edition = "2024"
 description = "LRU eviction of Docker images."


### PR DESCRIPTION
Bumps the version to 0.27.1 and documents the changes since 0.27.0.

**Status:** Ready

**Fixes:** N/A